### PR TITLE
BLD: lower python version required by "tests" GitHub workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       max-parallel: 1
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.12"]
+        python-version: ['3.10']
     env:
       DISPLAY: ':99.0'
       QT_MAC_WANTS_LAYER: 1  # PyQT gui tests involving qtbot interaction on macOS will fail without this
@@ -57,10 +57,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python 3.12
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: '3.10'
       - name: Install pypa/build
         run: |
           python -m pip install build --user

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,8 +4,6 @@ repo_name: slaclab/pydm-converter-tool
 
 nav:
   - Home: index.md
-  - How To:
-  - API Reference:
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[tool.setuptools.packages.find]
+include = ["pydmconverter"]
+
 [project.optional-dependencies]
 dev = [
     "pytest",


### PR DESCRIPTION
Requiring python version 3.12 caused this error in the MiniForge action:
```
  An unexpected error has occurred. Conda has prepared the above report.
  If you suspect this error is being caused by a malfunctioning plugin,
  consider using the --no-plugins option to turn off plugins.
  
  Example: conda --no-plugins install <package>
  
  Alternatively, you can set the CONDA_NO_PLUGINS environment variable on
  the command line to run the command without plugins enabled.
  
  Example: CONDA_NO_PLUGINS=true conda install <package>
  
  
  Looking for: ['python=3.12']
```