### PR TITLE
DOC: Add Docstrings to EDM Parser

### DIFF
--- a/pydmconverter/edm/parser.py
+++ b/pydmconverter/edm/parser.py
@@ -139,5 +139,5 @@ class EDMFileParser:
 
 if __name__ == "__main__":
     """Startup code to test the EDMFileParser class"""
-    parser = EDMFileParser(Path("../examples/all_bsy0_main_with_groups.edl"))
+    parser = EDMFileParser(Path("../../examples/all_bsy0_main_with_groups.edl"))
     pprint(parser.ui, indent=2)

--- a/pydmconverter/edm_parser.py
+++ b/pydmconverter/edm_parser.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 from pprint import pprint
 from dataclasses import dataclass, field
 
@@ -35,11 +36,21 @@ class EDMObject(EDMObjectBase):
 
 
 class EDMFileParser:
+    """EDMFileParser class parses .edl files and creates a tree of
+    EDMObjects and EDMGroups"""
+
     screen_prop_pattern = re.compile(r"beginScreenProperties(.*)endScreenProperties", re.DOTALL)
     group_pattern = re.compile(r"# \(Group\)(.*)endGroup", re.DOTALL)
     object_pattern = re.compile(r"# \(([^)]+)\)(.*?)endObjectProperties", re.DOTALL)
 
-    def __init__(self, file_path):
+    def __init__(self, file_path: str | Path):
+        """Creates an instance of EDMFileParser for the given file_path
+
+        Parameters
+        ----------
+        file_path : str | Path
+            EDM file to parse
+        """
         self.file_path = file_path
 
         with open(file_path, "r") as file:
@@ -52,7 +63,10 @@ class EDMFileParser:
         self.parse_screen_properties()
         self.parse_objects_and_groups(self.text[self.screen_properties_end :], self.ui)
 
-    def parse_screen_properties(self):
+    def parse_screen_properties(self) -> None:
+        """Get the screen properties from the .edl file and set the UI
+        height and width
+        """
         match = self.screen_prop_pattern.search(self.text)
         if match:
             screen_prop_text = match.group(1)
@@ -62,7 +76,18 @@ class EDMFileParser:
             self.ui.height = size_properties["height"]
             self.ui.width = size_properties["width"]
 
-    def parse_objects_and_groups(self, text, parent_group: EDMGroup):
+    def parse_objects_and_groups(self, text: str, parent_group: EDMGroup) -> None:
+        """Recursively parse the given text into a tree of EDMObjects and
+        EDMGroups. The parsed EDMObjects and EDMGroups are added to the
+        given parent_group, which is the root EDMGroup of the tree.
+
+        Parameters
+        ----------
+        text : str
+            Text from the file to be parsed
+        parent_group : EDMGroup
+            Parent EDMGroup to add the parsed EDMObjects and EDMGroups to
+        """
         pos = 0
         while pos < len(text):
             group_match = self.group_pattern.search(text, pos)
@@ -89,7 +114,20 @@ class EDMFileParser:
             else:
                 break
 
-    def get_size_properties(self, text):
+    @staticmethod
+    def get_size_properties(text: str) -> dict:
+        """Get the size properties from the given text (x, y, width, height)
+
+        Parameters
+        ----------
+        text : str
+            Text to extract size properties from
+
+        Returns
+        -------
+        dict
+            A dictionary containing the size properties from the text
+        """
         size_properties = {}
         size_properties["x"] = int(re.search(r"x (\d+)", text).group(1))
         size_properties["y"] = int(re.search(r"y (\d+)", text).group(1))
@@ -100,5 +138,6 @@ class EDMFileParser:
 
 
 if __name__ == "__main__":
-    parser = EDMFileParser("../../../examples/all_bsy0_main.edl")
+    """Startup code to test the EDMFileParser class"""
+    parser = EDMFileParser(Path("../examples/all_bsy0_main_with_groups.edl"))
     pprint(parser.ui, indent=2)


### PR DESCRIPTION
I should have added docstrings and documentation to the EDM Parser in #30. I am adding them now. Better late than never.

I also allowed the EDMFileParser to take either a string filepath or a pathlib.Path object.