### PR TITLE
ENH: Parse Object Properties

### DIFF
--- a/pydmconverter/edm/parser.py
+++ b/pydmconverter/edm/parser.py
@@ -34,9 +34,6 @@ class EDMObject(EDMObjectBase):
     name: str = ""
     properties: dict = field(default_factory=dict)
 
-    def add_property(self, key, value=True):
-        self.properties[key] = value
-
 
 class EDMFileParser:
     """EDMFileParser class parses .edl files and creates a tree of
@@ -59,7 +56,6 @@ class EDMFileParser:
         with open(file_path, "r") as file:
             self.text = file.read()
 
-        self.screen_properties = None
         self.screen_properties_end = 0
         self.ui = EDMGroup()
 

--- a/pydmconverter/edm/parser.py
+++ b/pydmconverter/edm/parser.py
@@ -40,8 +40,8 @@ class EDMFileParser:
     EDMObjects and EDMGroups"""
 
     screen_prop_pattern = re.compile(r"beginScreenProperties(.*)endScreenProperties", re.DOTALL)
-    group_pattern = re.compile(r"# \(Group\)(.*)endGroup", re.DOTALL)
-    object_pattern = re.compile(r"# \(([^)]+)\)(.*?)endObjectProperties", re.DOTALL)
+    group_pattern = re.compile(r"object activeGroupClass(.*)endGroup", re.DOTALL)
+    object_pattern = re.compile(r"object (\w+)(?:.*?)beginObjectProperties(.*?)endObjectProperties", re.DOTALL)
 
     def __init__(self, file_path: str | Path):
         """Creates an instance of EDMFileParser for the given file_path

--- a/tests/edm/test_parser.py
+++ b/tests/edm/test_parser.py
@@ -1,0 +1,173 @@
+import pytest
+import textwrap
+from pydmconverter.edm.parser import EDMGroup, EDMObject, EDMFileParser
+
+
+def test_EDMObject():
+    """Test that the EDMObject class can be instantiated with the correct
+    properties
+    """
+    obj = EDMObject(name="TestObject", properties={"key": "value"}, x=10, y=20, width=30, height=40)
+    assert obj.name == "TestObject"
+    assert obj.properties["key"] == "value"
+    assert obj.x == 10
+    assert obj.y == 20
+    assert obj.width == 30
+    assert obj.height == 40
+
+
+def test_EDMGroup():
+    """Test that the EDMGroup class can be instantiated with the correct
+    properties
+    """
+    group = EDMGroup()
+    obj = EDMObject(x=5, y=10)
+    group.add_object(obj)
+    assert obj in group.objects
+
+
+def test_missing_file(tmp_path):
+    """Test that an error is raised when the file does not exist
+
+    Parameters
+    ----------
+    tmp_path : pytest.fixture
+        Create a temorary directory for the test
+    """
+    test_file = tmp_path / "test.edl"
+
+    with pytest.raises(FileNotFoundError):
+        EDMFileParser(test_file)
+
+
+def test_parse_screen_properties(tmp_path):
+    """Test that the screen properties are parsed correctly
+
+    Parameters
+    ----------
+    tmp_path : pytest.fixture
+        Create a temorary directory for the test
+    """
+    test_data = textwrap.dedent("""
+        beginScreenProperties
+        x 10
+        y 20
+        w 30
+        h 40
+        endScreenProperties
+    """)
+    test_file = tmp_path / "test.edl"
+    test_file.write_text(test_data)
+
+    parser = EDMFileParser(test_file)
+    assert parser.ui.x == 0
+    assert parser.ui.y == 0
+    assert parser.ui.width == 30
+    assert parser.ui.height == 40
+
+
+def test_parse_objects(tmp_path):
+    """Test that the objects are parsed into EDMObject correctly
+
+    Parameters
+    ----------
+    tmp_path : pytest.fixture
+        Create a temorary directory for the test
+    """
+    test_data = textwrap.dedent("""
+        # (Rectangle)
+        object activeRectangleClass
+        beginObjectProperties
+        w 632
+        h 136
+        endObjectProperties
+
+        # (Static Text)
+        object activeXTextClass
+        beginObjectProperties
+        x 292
+        y 20
+        endObjectProperties
+    """)
+    test_file = tmp_path / "test.edl"
+    test_file.write_text(test_data)
+
+    parser = EDMFileParser(test_file)
+    assert len(parser.ui.objects) == 2
+    assert parser.ui.objects[0].name == "activeRectangleClass"
+    assert parser.ui.objects[1].name == "activeXTextClass"
+
+
+def test_parse_groups(tmp_path):
+    """Test that the groups are parsed into EDMGroup correctly
+
+    Parameters
+    ----------
+    tmp_path : pytest.fixture
+        Create a temorary directory for the test
+    """
+    test_data = textwrap.dedent("""
+        # (Group)
+        object activeGroupClass
+        beginObjectProperties
+        w 632
+        h 136
+        beginGroup
+
+        # (Static Text)
+        object activeXTextClass
+        beginObjectProperties
+        x 292
+        y 20
+        endObjectProperties
+
+        endGroup
+    """)
+    test_file = tmp_path / "test.edl"
+    test_file.write_text(test_data)
+
+    parser = EDMFileParser(test_file)
+    assert len(parser.ui.objects) == 1
+    assert len(parser.ui.objects[0].objects) == 1
+    assert parser.ui.objects[0].objects[0].name == "activeXTextClass"
+
+
+def test_get_size_properties():
+    """Test that the size properties are extracted correctly"""
+    test_data = textwrap.dedent("""
+        x 10
+        y 20
+        w 30
+        h 40
+        foo bar
+    """)
+
+    result_size = EDMFileParser.get_size_properties(test_data)
+    assert result_size["x"] == 10
+    assert result_size["y"] == 20
+    assert result_size["width"] == 30
+    assert result_size["height"] == 40
+    assert "foo" not in result_size
+
+
+@pytest.mark.parametrize(
+    "test_property, expected",
+    [
+        ("foo bar", {"foo": "bar"}),
+        ("baz", {"baz": True}),
+        ("qux {\nquux\ncorge\n}", {"qux": ["quux", "corge"]}),
+        ("qux {\n0 quux\n1 corge\n}", {"qux": ["quux", "corge"]}),
+    ],
+)
+def test_get_object_properties(test_property, expected):
+    """Test that the object properties are extracted correctly
+
+    Parameters
+    ----------
+    test_property : str
+        Test data for the object properties
+    expected : dict
+        Expected result of the object properties
+    """
+    result_property = EDMFileParser.get_object_properties(test_property)
+    assert result_property == expected


### PR DESCRIPTION
Get object properties from text for each EDM Object. This creates a dictionary consisting of the key-value pairs that properties are saved as in the EDM file.

The value of the dictionaries can be one of 3 types:
- `bool`: Object properties from the EDM file that don't have a value attached to it (e.g. `editable`)
- `str`: Object properties in a key-value pair (e.g. `numPoints 6`)
- `list[str]`: Multi-line properties that may or may not have a prepended index (example below)
```
yPoints {
  0 104
  1 40
}
value {
  "D2 Dump Status"
}
```

The parser cleans up the prepended indices if they exist. For example, the lists that the above examples would be converted to are represented as:
```python
{
'yPoints'`: ['104', '40']
'value': ['D2 Dump Status']
}
```