### PR TITLE
Convert long tuples into dataclasses

### DIFF
--- a/pydmconverter/edm/parser_helpers.py
+++ b/pydmconverter/edm/parser_helpers.py
@@ -2,6 +2,7 @@ import os
 import re
 import logging
 from typing import Dict, List, Optional, Tuple, Any
+from pydmconverter.types import RGBA
 
 logger = logging.getLogger(__name__)
 
@@ -818,7 +819,8 @@ def convert_color_property_to_qcolor(fillColor: str, color_data: Dict[str, Any])
         green = int(green * 255 / (max_val - 1))
         blue = int(blue * 255 / (max_val - 1))
 
-    result = (red, green, blue, alpha)
+    # result = (red, green, blue, alpha)
+    result = RGBA(r=red, g=green, b=blue, a=alpha)
     logger.info(f"Converted {fillColor} to color: {result}")
 
     return result

--- a/pydmconverter/types.py
+++ b/pydmconverter/types.py
@@ -8,6 +8,12 @@ class RGBA:
     b: int
     a: int = 255
 
+    def __iter__(self):
+        yield self.r
+        yield self.g
+        yield self.b
+        yield self.a
+
     def to_tuple(self):
         return (self.r, self.g, self.b, self.a)
 
@@ -20,6 +26,14 @@ class RuleArguments:
     initial_value: bool
     visMin: int
     visMax: int
+
+    def __iter__(self):
+        yield self.rule_type
+        yield self.channel
+        yield self.show_on_true
+        yield self.initial_value
+        yield self.visMin
+        yield self.visMax
 
     def to_tuple(self):
         return (self.rule_type, self.channel, self.show_on_true, self.initial_value, self.visMin, self.visMax)

--- a/pydmconverter/types.py
+++ b/pydmconverter/types.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RGBA:
+    r: int
+    g: int
+    b: int
+    a: int = 255
+
+    def to_tuple(self):
+        return (self.r, self.g, self.b, self.a)
+
+
+@dataclass(frozen=True)
+class RuleArguments:
+    rule_type: str
+    channel: str
+    show_on_true: bool
+    initial_value: bool
+    visMin: int
+    visMax: int
+
+    def to_tuple(self):
+        return (self.rule_type, self.channel, self.show_on_true, self.initial_value, self.visMin, self.visMax)

--- a/pydmconverter/widgets.py
+++ b/pydmconverter/widgets.py
@@ -138,8 +138,6 @@ class QLabel(Legible, StyleSheetObject):
     show_units: Optional[bool] = None
     tool_tip: Optional[str] = None
     frame_shape: Optional[str] = None
-    foreground_color: Optional[RGBA] = None
-    background_color: Optional[RGBA] = None
     alignment: Optional[str] = None
     useDisplayBg: Optional[bool] = None
     filename: Optional[str] = None
@@ -279,7 +277,7 @@ class PyDMDrawingRectangle(Alarmable, Drawable, Hidable):
         """
         properties: List[ET.Element] = super().generate_properties()
         if self.indicatorColor is not None:
-            properties.append(Brush(*self.indicatorColor, fill=True).to_xml())
+            properties.append(Brush(*self.indicatorColor.to_tuple(), fill=True).to_xml())
 
         return properties
 
@@ -1402,9 +1400,9 @@ class PyDMByteIndicator(Alarmable):
         if self.showLabels is not None:
             properties.append(Bool("showLabels", self.showLabels).to_xml())
         if self.on_color is not None:
-            properties.append(OnOffColor("on", *self.on_color).to_xml())
+            properties.append(OnOffColor("on", *self.on_color.to_tuple()).to_xml())
         if self.off_color is not None:
-            properties.append(OnOffColor("off", *self.off_color).to_xml())
+            properties.append(OnOffColor("off", *self.off_color.to_tuple()).to_xml())
 
         return properties
 
@@ -1429,7 +1427,7 @@ class PyDMWaveformPlot(Alarmable, StyleSheetObject):
                 Str("name", self.plot_name).to_xml()
             )  # Possibly overrides other name (may need to remove other name for plots)
         if self.color is not None:
-            properties.append(ColorObject("color", *self.color).to_xml())
+            properties.append(ColorObject("color", *self.color.to_tuple()).to_xml())
         if self.minXRange is not None:
             properties.append(Int("minXRange", self.minXRange).to_xml())
         if self.minYRange is not None:
@@ -1461,7 +1459,7 @@ class PyDMWaveformPlot(Alarmable, StyleSheetObject):
                 f'"x_channel": "{self.x_channel[i]}", '
                 f'"y_channel": "{self.y_channel[i]}", '
                 # f'"color": "rgba{str(self.plotColor[i])}"'
-                f'"color": "{self.rgba_to_hex(*self.plotColor[i])}"'
+                f'"color": "{self.rgba_to_hex(*self.plotColor[i].to_tuple())}"'
                 "}"
             )
             curve_string_list.append(curve_string)
@@ -1521,13 +1519,13 @@ class PyDMScaleIndicator(Alarmable):
         if self.minorTicks is not None or self.majorTicks is not None:
             properties.append(Int("numDivisions", int(self.minorTicks or 0) + int(self.majorTicks or 0)).to_xml())
         if self.indicatorColor is not None:
-            properties.append(ColorObject("indicatorColor", *self.indicatorColor).to_xml())
+            properties.append(ColorObject("indicatorColor", *self.indicatorColor.to_tuple()).to_xml())
         # if self.background_color is not None:
         #    styles: Dict[str, any] = {}
         #    styles["color"] = self.background_color
         #    properties.append(StyleSheet(styles).to_xml())
         if self.background_color is not None:
-            properties.append(ColorObject("backgroundColor", *self.background_color).to_xml())
+            properties.append(ColorObject("backgroundColor", *self.background_color.to_tuple()).to_xml())
         if self.foreground_color is not None:
             properties.append(ColorObject("tickColor", *self.foreground_color).to_xml())
         properties.append(TransparentBackground().to_xml())

--- a/pydmconverter/widgets.py
+++ b/pydmconverter/widgets.py
@@ -1,7 +1,7 @@
 from xml.etree import ElementTree as ET
 from dataclasses import dataclass, field
 from typing import List, Optional, Dict
-from pydmconverter.types import RGBA
+from pydmconverter.types import RGBA, RuleArguments
 from pydmconverter.widgets_helpers import (
     Int,
     Bool,
@@ -22,7 +22,6 @@ from pydmconverter.widgets_helpers import (
     StringList,
 )
 import logging
-from epics import PV
 
 
 @dataclass
@@ -517,19 +516,19 @@ class PyDMPushButton(PyDMPushButtonBase):
             A list of XML elements representing the PyDMPushButton properties.
         """
         if self.is_off_button is not None and not self.is_off_button:
-            self.rules.append(("Visible", self.channel, False, True, None, None))
-            self.rules.append(("Enable", self.channel, False, True, None, None))
-            if self.text is None and self.channel is not None:
-                pv = PV(self.channel)
-                if pv and pv.enum_strs and len(list(pv.enum_strs)) >= 2:
-                    self.text = pv.enum_strs[1]
+            self.rules.append(RuleArguments("Visible", self.channel, False, True, None, None))
+            self.rules.append(RuleArguments("Enable", self.channel, False, True, None, None))
+            # if self.text is None and self.channel is not None:
+            #    pv = PV(self.channel)
+            #    if pv and pv.enum_strs and len(list(pv.enum_strs)) >= 2:
+            #        self.text = pv.enum_strs[1]
         elif self.is_off_button is not None and self.is_off_button:
-            self.rules.append(("Visible", self.channel, False, False, None, None))
-            self.rules.append(("Enable", self.channel, False, False, None, None))
-            if self.text is None and self.channel is not None:
-                pv = PV(self.channel)
-                if pv and pv.enum_strs and len(list(pv.enum_strs)) >= 2:
-                    self.text = pv.enum_strs[0]
+            self.rules.append(RuleArguments("Visible", self.channel, False, False, None, None))
+            self.rules.append(RuleArguments("Enable", self.channel, False, False, None, None))
+            # if self.text is None and self.channel is not None:
+            #    pv = PV(self.channel)
+            #    if pv and pv.enum_strs and len(list(pv.enum_strs)) >= 2:
+            #        self.text = pv.enum_strs[0]
 
         properties: List[ET.Element] = super().generate_properties()
         if self.monitor_disp is not None:

--- a/pydmconverter/widgets.py
+++ b/pydmconverter/widgets.py
@@ -1,6 +1,7 @@
 from xml.etree import ElementTree as ET
 from dataclasses import dataclass, field
-from typing import List, Optional, Tuple, Dict
+from typing import List, Optional, Dict
+from pydmconverter.types import RGBA
 from pydmconverter.widgets_helpers import (
     Int,
     Bool,
@@ -137,8 +138,8 @@ class QLabel(Legible, StyleSheetObject):
     show_units: Optional[bool] = None
     tool_tip: Optional[str] = None
     frame_shape: Optional[str] = None
-    foreground_color: Optional[Tuple[int, int, int, int]] = None
-    background_color: Optional[Tuple[int, int, int, int]] = None
+    foreground_color: Optional[RGBA] = None
+    background_color: Optional[RGBA] = None
     alignment: Optional[str] = None
     useDisplayBg: Optional[bool] = None
     filename: Optional[str] = None
@@ -261,11 +262,11 @@ class PyDMDrawingRectangle(Alarmable, Drawable, Hidable):
 
     Attributes
     ----------
-    indicatorColor: Optional[Tuple[int, int, int, int]]
+    indicatorColor: Optional[RGBA]
         The fill color for specifically activebar/slacbarclass rectangles
     """
 
-    indicatorColor: Optional[Tuple[int, int, int, int]] = None
+    indicatorColor: Optional[RGBA] = None
 
     def generate_properties(self) -> List[ET.Element]:
         """
@@ -493,14 +494,12 @@ class PyDMPushButton(PyDMPushButtonBase):
     release_value: Optional[str] = None
     relative_change: Optional[bool] = None
     write_when_release: Optional[bool] = None
-    on_color: Optional[Tuple[int, int, int, int]] = (
+    on_color: Optional[RGBA] = None  # TODO: clean up where these attributes are called to a parent to reduce redundancy
+    off_color: Optional[RGBA] = (
         None  # TODO: clean up where these attributes are called to a parent to reduce redundancy
     )
-    off_color: Optional[Tuple[int, int, int, int]] = (
-        None  # TODO: clean up where these attributes are called to a parent to reduce redundancy
-    )
-    foreground_color: Optional[Tuple[int, int, int, int]] = None
-    background_color: Optional[Tuple[int, int, int, int]] = None
+    foreground_color: Optional[RGBA] = None
+    background_color: Optional[RGBA] = None
     useDisplayBg: Optional[bool] = None
     on_label: Optional[str] = None
     off_label: Optional[str] = None
@@ -980,7 +979,6 @@ class PyDMDrawingLine(Legible, Drawable, Alarmable):
         Class variable tracking the number of PyDMDrawingLine instances.
     """
 
-    pen_color: Optional[Tuple[int, int, int]] = None  # maybe can remove
     pen_width: Optional[int] = None
     arrow_size: Optional[int] = None
     arrow_end_point: Optional[bool] = None
@@ -988,7 +986,7 @@ class PyDMDrawingLine(Legible, Drawable, Alarmable):
     arrow_mid_point: Optional[bool] = None
     flip_mid_point_arrow: Optional[bool] = None
     arrows: Optional[str] = None
-    penColor: Optional[Tuple[int, int, int, int]] = None
+    penColor: Optional[RGBA] = None
 
     def generate_properties(self) -> List[ET.Element]:
         """
@@ -1380,14 +1378,14 @@ class PyDMByteIndicator(Alarmable):
     Attributes:
         numBits (Optional[int]): Number of bits to display.
         showLabels (Optional[bool]): Whether to show bit labels.
-        on_color (Optional[Tuple[int, int, int, int]]): RGBA color when a bit is on.
-        off_color (Optional[Tuple[int, int, int, int]]): RGBA color when a bit is off.
+        on_color (Optional[RGBA]): RGBA color when a bit is on.
+        off_color (Optional[RGBA]): RGBA color when a bit is off.
     """
 
     numBits: Optional[int] = None
     showLabels: Optional[bool] = None
-    on_color: Optional[Tuple[int, int, int, int]] = None
-    off_color: Optional[Tuple[int, int, int, int]] = None
+    on_color: Optional[RGBA] = None
+    off_color: Optional[RGBA] = None
 
     def generate_properties(self) -> List[ET.Element]:
         """
@@ -1416,12 +1414,12 @@ class PyDMWaveformPlot(Alarmable, StyleSheetObject):
     x_channel: Optional[List[str]] = None
     y_channel: Optional[List[str]] = None
     plot_name: Optional[str] = None
-    color: Optional[Tuple[int, int, int, int]] = None
+    color: Optional[RGBA] = None
     minXRange: Optional[int] = None
     minYRange: Optional[int] = None
     maxXRange: Optional[int] = None
     maxYRange: Optional[int] = None
-    plotColor: Optional[List[Tuple[int, int, int, int]]] = None
+    plotColor: Optional[List[RGBA]] = None
 
     def generate_properties(self) -> List[ET.Element]:
         properties: List[ET.Element] = super().generate_properties()
@@ -1495,9 +1493,9 @@ class PyDMScaleIndicator(Alarmable):
     # numDivisions: Optional[int] = None
     minorTicks: Optional[int] = None
     majorTicks: Optional[int] = None
-    indicatorColor: Optional[Tuple[int, int, int, int]] = None
-    background_color: Optional[Tuple[int, int, int, int]] = None
-    foreground_color: Optional[Tuple[int, int, int, int]] = None
+    indicatorColor: Optional[RGBA] = None
+    background_color: Optional[RGBA] = None
+    foreground_color: Optional[RGBA] = None
 
     def generate_properties(self) -> List[ET.Element]:
         """

--- a/pydmconverter/widgets.py
+++ b/pydmconverter/widgets.py
@@ -276,7 +276,7 @@ class PyDMDrawingRectangle(Alarmable, Drawable, Hidable):
         """
         properties: List[ET.Element] = super().generate_properties()
         if self.indicatorColor is not None:
-            properties.append(Brush(*self.indicatorColor.to_tuple(), fill=True).to_xml())
+            properties.append(Brush(*self.indicatorColor, fill=True).to_xml())
 
         return properties
 
@@ -1399,9 +1399,9 @@ class PyDMByteIndicator(Alarmable):
         if self.showLabels is not None:
             properties.append(Bool("showLabels", self.showLabels).to_xml())
         if self.on_color is not None:
-            properties.append(OnOffColor("on", *self.on_color.to_tuple()).to_xml())
+            properties.append(OnOffColor("on", *self.on_color).to_xml())
         if self.off_color is not None:
-            properties.append(OnOffColor("off", *self.off_color.to_tuple()).to_xml())
+            properties.append(OnOffColor("off", *self.off_color).to_xml())
 
         return properties
 
@@ -1426,7 +1426,7 @@ class PyDMWaveformPlot(Alarmable, StyleSheetObject):
                 Str("name", self.plot_name).to_xml()
             )  # Possibly overrides other name (may need to remove other name for plots)
         if self.color is not None:
-            properties.append(ColorObject("color", *self.color.to_tuple()).to_xml())
+            properties.append(ColorObject("color", *self.color).to_xml())
         if self.minXRange is not None:
             properties.append(Int("minXRange", self.minXRange).to_xml())
         if self.minYRange is not None:
@@ -1458,7 +1458,7 @@ class PyDMWaveformPlot(Alarmable, StyleSheetObject):
                 f'"x_channel": "{self.x_channel[i]}", '
                 f'"y_channel": "{self.y_channel[i]}", '
                 # f'"color": "rgba{str(self.plotColor[i])}"'
-                f'"color": "{self.rgba_to_hex(*self.plotColor[i].to_tuple())}"'
+                f'"color": "{self.rgba_to_hex(*self.plotColor[i])}"'
                 "}"
             )
             curve_string_list.append(curve_string)
@@ -1518,13 +1518,13 @@ class PyDMScaleIndicator(Alarmable):
         if self.minorTicks is not None or self.majorTicks is not None:
             properties.append(Int("numDivisions", int(self.minorTicks or 0) + int(self.majorTicks or 0)).to_xml())
         if self.indicatorColor is not None:
-            properties.append(ColorObject("indicatorColor", *self.indicatorColor.to_tuple()).to_xml())
+            properties.append(ColorObject("indicatorColor", *self.indicatorColor).to_xml())
         # if self.background_color is not None:
         #    styles: Dict[str, any] = {}
         #    styles["color"] = self.background_color
         #    properties.append(StyleSheet(styles).to_xml())
         if self.background_color is not None:
-            properties.append(ColorObject("backgroundColor", *self.background_color.to_tuple()).to_xml())
+            properties.append(ColorObject("backgroundColor", *self.background_color).to_xml())
         if self.foreground_color is not None:
             properties.append(ColorObject("tickColor", *self.foreground_color).to_xml())
         properties.append(TransparentBackground().to_xml())

--- a/pydmconverter/widgets_helpers.py
+++ b/pydmconverter/widgets_helpers.py
@@ -833,11 +833,9 @@ class MultiRule(XMLConvertible):
     def to_string(self):
         channel_list = []
         expression_list = []
-        print(self.rule_list)
-        breakpoint()
         if self.rule_list is not None:
             for i, rule in enumerate(self.rule_list):
-                rule_type, channel, initial_value, show_on_true, visMin, visMax = rule.to_tuple()
+                rule_type, channel, initial_value, show_on_true, visMin, visMax = rule
                 print(rule_type, channel, show_on_true)
                 breakpoint()
                 channel_list.append(f'{{"channel": "{channel}", "trigger": true, "use_enum": false}}')
@@ -886,8 +884,6 @@ class Rules(XMLConvertible):
     hide_on_disconnect_channel: Optional[str] = None
 
     def to_xml(self):
-        print(self.rules)
-        breakpoint()
         # bool_rule_types = set(["Visible", "Enable"])
         rule_list = []
         rule_variables = self.group_by_rules()
@@ -943,7 +939,7 @@ class StyleSheet(XMLConvertible):
 
     def _format_value(self, key: str, value: Any) -> str:
         if isinstance(value, RGBA) and key in ("color", "background-color"):
-            r, g, b, *a = value.to_tuple()
+            r, g, b, *a = value
             alpha = a[0] if a else 1.0
             return f"{key}: rgba({r}, {g}, {b}, {round(alpha, 2)});"
         return f"{key}: {value};"
@@ -1530,13 +1526,13 @@ class Drawable(Tangible):
         """
         properties: List[etree.Element] = super().generate_properties()
         if self.penColor is not None:
-            properties.append(PenColor(*self.penColor.to_tuple()).to_xml())
+            properties.append(PenColor(*self.penColor).to_xml())
         if self.penStyle is not None or self.penColor is not None:
             properties.append(PenStyle(style=self.penStyle).to_xml())
         if self.penWidth is not None:
             properties.append(PenWidth(width=self.penWidth).to_xml())
         if self.brushColor is not None:
-            properties.append(Brush(*self.brushColor.to_tuple(), fill=self.brushFill).to_xml())
+            properties.append(Brush(*self.brushColor, fill=self.brushFill).to_xml())
         if self.brushFill is None:
             properties.append(TransparentBackground().to_xml())
         if self.rotation is not None:

--- a/pydmconverter/widgets_helpers.py
+++ b/pydmconverter/widgets_helpers.py
@@ -936,8 +936,8 @@ class StyleSheet(XMLConvertible):
     styles: Dict[str, Any]
 
     def _format_value(self, key: str, value: Any) -> str:
-        if isinstance(value, tuple) and key in ("color", "background-color"):
-            r, g, b, *a = value
+        if isinstance(value, RGBA) and key in ("color", "background-color"):
+            r, g, b, *a = value.to_tuple()
             alpha = a[0] if a else 1.0
             return f"{key}: rgba({r}, {g}, {b}, {round(alpha, 2)});"
         return f"{key}: {value};"
@@ -1524,13 +1524,13 @@ class Drawable(Tangible):
         """
         properties: List[etree.Element] = super().generate_properties()
         if self.penColor is not None:
-            properties.append(PenColor(*self.penColor).to_xml())
+            properties.append(PenColor(*self.penColor.to_tuple()).to_xml())
         if self.penStyle is not None or self.penColor is not None:
             properties.append(PenStyle(style=self.penStyle).to_xml())
         if self.penWidth is not None:
             properties.append(PenWidth(width=self.penWidth).to_xml())
         if self.brushColor is not None:
-            properties.append(Brush(*self.brushColor, fill=self.brushFill).to_xml())
+            properties.append(Brush(*self.brushColor.to_tuple(), fill=self.brushFill).to_xml())
         if self.brushFill is None:
             properties.append(TransparentBackground().to_xml())
         if self.rotation is not None:

--- a/pydmconverter/widgets_helpers.py
+++ b/pydmconverter/widgets_helpers.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field, fields
 from typing import Any, ClassVar, List, Optional, Tuple, Union, Dict
 import xml.etree.ElementTree as etree
 from xml.etree import ElementTree as ET
+from pydmconverter.types import RGBA
 
 ALARM_CONTENT_DEFAULT = False
 ALARM_BORDER_DEFAULT = True
@@ -991,7 +992,7 @@ class TransparentBackground(XMLConvertible):
 class Curves(XMLConvertible):
     x_channel: Optional[str] = None
     y_channel: Optional[str] = None
-    plotColor: Optional[Tuple[int, int, int, int]] = None
+    plotColor: Optional[RGBA] = None
 
 
 @dataclass
@@ -1441,14 +1442,14 @@ class StyleSheetObject(Tangible):
 
     Attributes
     ----------
-    foreground_color : Optional[Tuple[int, int, int, int]]
+    foreground_color : Optional[RGBA]
         RGBA color tuple for the foreground (text) color.
-    background_color : Optional[Tuple[int, int, int, int]]
+    background_color : Optional[RGBA]
         RGBA color tuple for the background color.
     """
 
-    foreground_color: Optional[Tuple[int, int, int, int]] = None
-    background_color: Optional[Tuple[int, int, int, int]] = None
+    foreground_color: Optional[RGBA] = None
+    background_color: Optional[RGBA] = None
     useDisplayBg: Optional[bool] = None
     name: Optional[str] = ""
 
@@ -1480,8 +1481,8 @@ class StyleSheetObject(Tangible):
 
 @dataclass
 class OnOffObject(Tangible):
-    on_color: Optional[Tuple[int, int, int, int]] = None
-    off_color: Optional[Tuple[int, int, int, int]] = None
+    on_color: Optional[RGBA] = None
+    off_color: Optional[RGBA] = None
 
 
 @dataclass
@@ -1493,11 +1494,11 @@ class Drawable(Tangible):
     ----------
     penStyle : Optional[str]
         The style of the pen ('dash' for dashed, otherwise solid).
-    penColor : Optional[Tuple[int, int, int, int]]
+    penColor : Optional[RGBA]
         A tuple representing the pen color (red, green, blue, alpha).
     penWidth : Optional[int]
         The width of the pen.
-    brushColor : Optional[Tuple[int, int, int, int]]
+    brushColor : Optional[RGBA]
         A tuple representing the brush color (red, green, blue, alpha).
     brushFill : Optional[bool]
         Whether the brush should fill.
@@ -1506,9 +1507,9 @@ class Drawable(Tangible):
     """
 
     penStyle: Optional[str] = None
-    penColor: Optional[Tuple[int, int, int, int]] = None
+    penColor: Optional[RGBA] = None
     penWidth: Optional[int] = None
-    brushColor: Optional[Tuple[int, int, int, int]] = None
+    brushColor: Optional[RGBA] = None
     brushFill: Optional[bool] = None
     rotation: Optional[float] = None
 


### PR DESCRIPTION
**Convert reused tuples including RGBA and RuleArgument (inputs for pydm rules) tuples into dataclasses.**

Purpose: Allow for improved type hinting and readability for hard to understand or complicated tuples

Changes:

Created types.py file:
- Includes definitions for RGBA and RuleArguments dataclasses and allows for classes to be iterable

Modified other files:
- Changed tuples used into dataclasses
- Changed docstrings to reflect the changes