### PR TITLE
BUG: Set minimum height/width to 2 (was not appearing when width=1)

### DIFF
--- a/pydmconverter/widgets_helpers.py
+++ b/pydmconverter/widgets_helpers.py
@@ -1550,7 +1550,7 @@ class Tangible(XMLSerializableMixin):
             A list containing the geometry property.
         """
         properties: List[etree.Element] = []
-        properties.append(Geometry(self.x, self.y, self.width, self.height).to_xml())
+        properties.append(Geometry(self.x, self.y, max(self.width, 2), max(self.height, 2)).to_xml())
         if self.secretId is not None:
             properties.append(Str("secretId", self.secretId).to_xml())
             breakpoint()


### PR DESCRIPTION
This pr sets the minimum height/width of PyDM widgets to 2 to allow them to show up (width = 1 rectangles show up in EDM but not PyDM)

This pr fixes #83