### PR TITLE
FIX: Embedded Display Issue 

### DIFF
--- a/pydmconverter/edm/converter_helpers.py
+++ b/pydmconverter/edm/converter_helpers.py
@@ -462,7 +462,6 @@ def convert_edm_to_pydm_widgets(parser: EDMFileParser):
         offset_y: float = 0,
         central_widget: EDMGroup = None,
         parent_vispvs: Optional[List[Tuple[str, int, int]]] = None,
-        output_file_path=None,
         # parent_vis_range: Optional[Tuple[int, int]] = None,
     ):
         menu_mux_buttons = []
@@ -524,7 +523,6 @@ def convert_edm_to_pydm_widgets(parser: EDMFileParser):
                     offset_y=0,
                     central_widget=central_widget,
                     parent_vispvs=(parent_vispvs or []) + curr_vispv + symbol_vispv,
-                    output_file_path=output_file_path,
                     # parent_vis_range=(parent_vis_range or []) + curr_vis_range,
                 )
 
@@ -795,7 +793,6 @@ def convert_edm_to_pydm_widgets(parser: EDMFileParser):
         None,
         parser.ui.height,
         central_widget=parser.ui,
-        output_file_path=parser.file_path,
     )
 
     pydm_widgets = handle_button_polygon_overlaps(pydm_widgets)

--- a/pydmconverter/widgets.py
+++ b/pydmconverter/widgets.py
@@ -1192,7 +1192,7 @@ class PyDMEmbeddedDisplay(Alarmable, Hidable, Drawable):
         if self.visible is not None:
             properties.append(Bool("visible", self.visible).to_xml())
         if self.noscroll is not None:
-            scroll: bool = not self.noscroll
+            scroll: Bool = not self.noscroll
             properties.append(Bool("scrollable", scroll).to_xml())
         if (
             self.foreground_color is not None


### PR DESCRIPTION
## Description
Fixed conversion of EDM activePipClass (embedded windows) to PyDM PyDMEmbeddedDisplay widgets. Embedded displays were previously missing critical properties, causing them to fail to load in PyDM.

1. Fail to load with FileNotFoundError (missing filename)
2. Fail to load with ValueError (incorrect macros format)
3. Share LOC variable state between instances 

Fixed these issue with:
1. Added filename extraction for single embedded displays
2. Fixed macros format for embedded displays 
3. Made LOC variables unique in cases where the EDM lOC has a $(!W). Changed parser to replace $(!W) with __UNIQUE__ marker (instead of removing it). Then converter detects __UNIQUE__ marker and replaces with unique widget ID

## Testing
Tested with EDM screens with activePipClass 