### PR TITLE
FIX: ValueError when converting slider widgets with scientific notation values

### DIFF
--- a/pydmconverter/widgets_helpers.py
+++ b/pydmconverter/widgets_helpers.py
@@ -385,7 +385,13 @@ class Int(XMLConvertible):
         """
         prop: etree.Element = etree.Element("property", attrib={"name": self.name, "stdset": "0"})
         int_tag: etree.Element = etree.SubElement(prop, "number")
-        int_tag.text = str(self.value)
+        # Convert through float first to handle scientific notation (e.g., '-2e+08')
+        # PyQt's uic parser cannot handle scientific notation in <number> elements
+        try:
+            int_value = int(float(self.value))
+        except (ValueError, TypeError):
+            int_value = 0
+        int_tag.text = str(int_value)
         return prop
 
 


### PR DESCRIPTION
## Description
Fix to ValueError when opening converted screens containing slider widgets with scientific notation values (e.g., `-2e+08`)

closes https://github.com/slaclab/pydm-converter-tool/issues/108