### PR TITLE
FIX: set transparent background for flat buttons without bgColor

### DIFF
--- a/pydmconverter/widgets.py
+++ b/pydmconverter/widgets.py
@@ -586,7 +586,7 @@ class PyDMPushButton(PyDMPushButtonBase):
             self.on_color is not None
             or self.foreground_color is not None
             or self.background_color is not None
-            or (self.flat is True and self.background_color is None and self.on_color is None)
+            or self.flat is True
             or (
                 isinstance(self.name, str)
                 and (


### PR DESCRIPTION
# Description
Fixes an issue where related display buttons with the `flat` property set to `true` but no background color would not appear correctly in embedded displays.

Modified `PyDMPushButton.generate_properties()` in `widgets.py` to check for flat buttons without background colors
When `flat=true` and no `background_color` or `on_color` is set, the stylesheet now includes `background-color: transparent`

closes https://github.com/slaclab/pydm-converter-tool/issues/107
