### PR TITLE
FIX: convert EDM screen title property to PyDM windowTitle

### DIFF
--- a/pydmconverter/widgets_helpers.py
+++ b/pydmconverter/widgets_helpers.py
@@ -1910,11 +1910,14 @@ class PageHeader:
 
         ET.SubElement(rect, "width").text = str(edm_parser.ui.width)
         ET.SubElement(rect, "height").text = str(edm_parser.ui.height)
-        window_title = ET.SubElement(main_widget, "property", attrib={"name": "windowTitle"})
-        title_string = ET.SubElement(window_title, "string")
-        title_string.text = "PyDM Screen"
 
         screen_properties: dict[str, str] = edm_parser.ui.properties
+
+        # Set window title from EDM screen properties if available, otherwise use default
+        window_title = ET.SubElement(main_widget, "property", attrib={"name": "windowTitle"})
+        title_string = ET.SubElement(window_title, "string")
+        title_string.text = screen_properties.get("title", "PyDM Screen")
+
         self.add_screen_properties(main_widget, screen_properties)
 
         if scrollable:


### PR DESCRIPTION
## Description
Fixes bug where EDM screen titles were not being converted to PyDM window titles.

## Problem
When converting EDM files to PyDM, the window title was always set to the hard coded string "PyDM Screen", even though the EDM parser was correctly reading the `title` property from the EDM screen properties.

## Solution
Modified `PageHeader.create_page_header()` in `widgets_helpers.py` to:
Read the `title` property from the EDM screen properties dictionary
Set the PyDM `windowTitle` to the EDM title if present
Fall back to "PyDM Screen" as default if no title property exists

Closes https://github.com/slaclab/pydm-converter-tool/issues/105