### PR TITLE
FIX: set show_units=true for text update widgets during EDM conversion

### DIFF
--- a/pydmconverter/edm/converter_helpers.py
+++ b/pydmconverter/edm/converter_helpers.py
@@ -562,6 +562,13 @@ def convert_edm_to_pydm_widgets(parser: EDMFileParser):
                 if parent_vispvs:
                     setattr(widget, "visPvList", list(parent_vispvs))
 
+                # TextupdateClass widgets always show units in EDM, so set show_units to True
+                # unless explicitly specified otherwise in the EDM properties
+                if obj.name.lower() in ("textupdateclass", "multilinetextupdateclass", "regtextupdateclass"):
+                    if "showUnits" not in obj.properties:
+                        setattr(widget, "show_units", True)
+                        logger.info(f"Set show_units=True for {obj.name} (implicit EDM behavior)")
+
                 # Set mapped attributes.
                 for edm_attr, value in obj.properties.items():
                     pydm_attr = EDM_TO_PYDM_ATTRIBUTES.get(edm_attr)


### PR DESCRIPTION
## Description
Fixes text update widgets not showing units after conversion from EDM to PyDM.

## Problem
EDM's `TextupdateClass` widgets implicitly always show units, but when converted to PyDM `PyDMLabel` widgets, the units were not displayed because the `show_units` property was not being set.

## Solution
Modified `converter_helpers.py` to automatically set `show_units=True` for all text update widget types (`textupdateclass`, `multilinetextupdateclass`, `regtextupdateclass`) unless explicitly specified otherwise in the EDM properties.

## Testing
Tested with `watr_li22_watrTemp.edl` 

Closes https://github.com/slaclab/pydm-converter-tool/issues/106