### PR TITLE
FIX: Related display dropdown shows titles instead of file names

### DIFF
--- a/pydmconverter/edm/converter_helpers.py
+++ b/pydmconverter/edm/converter_helpers.py
@@ -162,6 +162,7 @@ EDM_TO_PYDM_ATTRIBUTES = {
     "command": "command",
     "numCmds": "numCmds",
     "commandLabel": "titles",
+    "menuLabel": "titles",
     # Related display attributes
     "fileName": "filename",
     "macro": "macros",

--- a/pydmconverter/widgets.py
+++ b/pydmconverter/widgets.py
@@ -736,7 +736,10 @@ class PyDMRelatedDisplayButton(PyDMPushButtonBase):
         # if self.filenames is not None:
         #    properties.append(Str("filenames", self.filenames).to_xml()) #TODO: Maybe come back and include this if it comes up in edm
         if self.titles is not None:
-            properties.append(Str("titles", self.titles).to_xml())
+            if isinstance(self.titles, list):
+                properties.append(StringList("titles", self.titles).to_xml())
+            else:
+                properties.append(Str("titles", self.titles).to_xml())
         if self.macros is not None:
             properties.append(Str("macros", self.macros).to_xml())
         # if self.open_in_new_window is not None:

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -405,6 +405,23 @@ def test_pydmrelateddisplay_button_generate_properties():
     assert prop_dict.get("followSymlinks") == "false"
 
 
+def test_pydmrelateddisplay_button_list_titles():
+    """Test that list-valued titles are serialized as a StringList."""
+    widget = PyDMRelatedDisplayButton()
+    widget.titles = ["asynOctet Interface I/O", "Register interfaces I/O", "Serial port parameters"]
+    widget.displayFileName = ["asynOctet.edl", "asynRegister.edl", "asynSerialPortSetup.edl"]
+
+    properties: List[ET.Element] = widget.generate_properties()
+
+    titles_prop = next((p for p in properties if p.get("name") == "titles"), None)
+    assert titles_prop is not None
+    # Should be a stringlist, not a plain string
+    stringlist = titles_prop.find("stringlist")
+    assert stringlist is not None
+    strings = [s.text for s in stringlist.findall("string")]
+    assert strings == ["asynOctet Interface I/O", "Register interfaces I/O", "Serial port parameters"]
+
+
 # --- Tests for QComboBox ---
 
 


### PR DESCRIPTION
## Description 
EDM menuLabel property was not mapped in the converter, causing
related display dropdowns to show file names instead of human-readable
titles. Added menuLabel → titles mapping and handled list-valued titles
as StringList.

Closes #116