### PR TITLE
FIX: escaped double quotes in shell command conversion

### DIFF
--- a/pydmconverter/edm/parser.py
+++ b/pydmconverter/edm/parser.py
@@ -631,12 +631,12 @@ class EDMFileParser:
                     properties[multi_line_key] = cleaned_prop
                     multi_line_prop = []
                 else:
-                    multi_line_prop.append(line.strip(' "'))
+                    multi_line_prop.append(line.strip(' "').replace('\\"', '"'))
                 continue
 
             try:
                 k, v = line.split(maxsplit=1)
-                v = v.strip(' "')
+                v = v.strip(' "').replace('\\"', '"')
             except ValueError:
                 k, v = line, True
 
@@ -673,7 +673,7 @@ class EDMFileParser:
             try:
                 k, v = line.split(maxsplit=1)
                 indices.append(int(k))
-                values.append(v.strip(' "'))
+                values.append(v.strip(' "').replace('\\"', '"'))
             except ValueError:
                 return lines
 

--- a/tests/edm/test_parser.py
+++ b/tests/edm/test_parser.py
@@ -167,6 +167,11 @@ def test_get_size_properties():
         ("baz", {"baz": True}),
         ("qux {\nquux\ncorge\n}", {"qux": ["quux", "corge"]}),
         ("qux {\n0 quux\n1 corge\n}", {"qux": ["quux", "corge"]}),
+        (
+            'command {\n  0 "pydm -m \\"DEV=WIGG:LTUS:724\\" file.ui &"\n}',
+            {"command": ['pydm -m "DEV=WIGG:LTUS:724" file.ui &']},
+        ),
+        ('label "some \\"quoted\\" text"', {"label": 'some "quoted" text'}),
     ],
 )
 def test_get_object_properties(test_property, expected):


### PR DESCRIPTION
## Description
- Unescape \ " to " in EDM parser's get_object_properties and remove_prepended_index methods
- Affects all quoted string values: single-line properties, multi-line properties, and indexed list entries
- Added parametrized tests for both indexed and single-line escaped quote cases

Closes #117