### PR TITLE
ENH: Convert EDM meter widget to PyDMAnalogIndicator

### DIFF
--- a/pydmconverter/edm/converter.py
+++ b/pydmconverter/edm/converter.py
@@ -47,6 +47,7 @@ CUSTOM_WIDGET_DEFINITIONS = {
     "PyDMShellCommand": {"extends": "QPushButton", "header": "pydm.widgets.shell_command", "container": ""},
     "PyDMSlider": {"extends": "QWidget", "header": "pydm.widgets.slider", "container": ""},
     "PyDMWaveformTable": {"extends": "QTableWidget", "header": "pydm.widgets.waveformtable", "container": ""},
+    "PyDMAnalogIndicator": {"extends": "QWidget", "header": "pydm.widgets.analog_indicator", "container": ""},
 }
 
 

--- a/pydmconverter/edm/converter_helpers.py
+++ b/pydmconverter/edm/converter_helpers.py
@@ -26,6 +26,7 @@ from pydmconverter.widgets import (
     PyDMScaleIndicator,
     PyDMSlider,
     PyDMWaveformTable,
+    PyDMAnalogIndicator,
 )
 from pydmconverter.edm.parser_helpers import convert_color_property_to_qcolor, search_color_list, parse_colors_list
 from pydmconverter.edm.menumux import generate_menumux_file
@@ -45,7 +46,8 @@ EDM_TO_PYDM_WIDGETS = {  # missing PyDMFrame,  QComboBox
     # "image": PyDMImageView,
     "activextextclass": PyDMLabel,
     # Monitors
-    # "meter": PyDMMeter,
+    "activemeterclass": PyDMAnalogIndicator,
+    "meter": PyDMAnalogIndicator,
     # "bar": PyDMBar,
     # "xy_graph": PyDMScatterPlot,
     # "byte_indicator": PyDMByteIndicator,
@@ -241,6 +243,8 @@ COLOR_ATTRIBUTES: set = {
     "indicatorColor",
     "frozenBgColor",
     "gridColor",
+    "barColor",
+    "scaleColor",
 }
 
 logging.basicConfig(level=logging.INFO)
@@ -697,6 +701,11 @@ def apply_widget_post_processing(
     # Auto-size
     if obj.properties.get("autoSize", False) and hasattr(widget, "autoSize"):
         widget.autoSize = True
+
+    if obj.properties.get("showScale") and isinstance(widget, PyDMAnalogIndicator):
+        widget.showTicks = True
+        widget.showLimits = True
+        widget.showUnits = True
 
 
 def traverse_group(

--- a/pydmconverter/widgets.py
+++ b/pydmconverter/widgets.py
@@ -1853,3 +1853,39 @@ class PyDMSlider(Alarmable):
             properties.append(Int("userMaximum", self.max).to_xml())
 
         return properties
+
+
+@dataclass
+class PyDMAnalogIndicator(Alarmable):
+
+    showTicks: Optional[bool] = None
+    showLimits: Optional[bool] = None
+    showUnits: Optional[bool] = None
+    showValue: Optional[bool] = None
+    precision: Optional[int] = None
+    indicatorColor: Optional[RGBA] = None
+    background_color: Optional[RGBA] = None
+    foreground_color: Optional[RGBA] = None
+
+    def generate_properties(self) -> List[ET.Element]:
+        properties: List[ET.Element] = super().generate_properties()
+
+        if self.showTicks is not None:
+            properties.append(Bool("showTicks", self.showTicks).to_xml())
+        if self.showLimits is not None:
+            properties.append(Bool("showLimits", self.showLimits).to_xml())
+        if self.showUnits is not None:
+            properties.append(Bool("showUnits", self.showUnits).to_xml())
+        if self.showValue is not None:
+            properties.append(Bool("showValue", self.showValue).to_xml())
+        if self.precision is not None:
+            properties.append(Int("precision", self.precision).to_xml())
+        if self.indicatorColor is not None:
+            properties.append(ColorObject("indicatorColor", *self.indicatorColor).to_xml())
+        if self.background_color is not None:
+            properties.append(ColorObject("backgroundColor", *self.background_color).to_xml())
+        if self.foreground_color is not None:
+            properties.append(ColorObject("tickColor", *self.foreground_color).to_xml())
+        properties.append(TransparentBackground().to_xml())
+
+        return properties

--- a/pydmconverter/widgets.py
+++ b/pydmconverter/widgets.py
@@ -1857,7 +1857,6 @@ class PyDMSlider(Alarmable):
 
 @dataclass
 class PyDMAnalogIndicator(Alarmable):
-
     showTicks: Optional[bool] = None
     showLimits: Optional[bool] = None
     showUnits: Optional[bool] = None

--- a/tests/edm/test_converter.py
+++ b/tests/edm/test_converter.py
@@ -345,3 +345,69 @@ def test_convert_shell_command_to_commands_property(tmp_path):
     assert len(strings) == 2, "Should have 2 commands"
     assert strings[0].text == "echo hello", "First command should be 'echo hello'"
     assert strings[1].text == "echo world", "Second command should be 'echo world'"
+
+
+def test_convert_meter_widget(tmp_path):
+    """Test that EDM meter widget converts to PyDMAnalogIndicator."""
+    edm_content = textwrap.dedent("""
+        4 0 1
+        beginScreenProperties
+        major 4
+        minor 0
+        release 1
+        x 0
+        y 0
+        w 800
+        h 600
+        endScreenProperties
+
+        # (Meter)
+        object activeMeterClass
+        beginObjectProperties
+        major 4
+        minor 0
+        release 1
+        x 100
+        y 100
+        w 150
+        h 150
+        readPv "IOC:SYS0:PRESSURE"
+        scaleMin 0
+        scaleMax 100
+        showScale
+        fgColor index 14
+        bgColor index 0
+        endObjectProperties
+    """)
+
+    input_file = tmp_path / "test.edl"
+    output_file = tmp_path / "test.ui"
+    input_file.write_text(edm_content)
+
+    convert(str(input_file), str(output_file))
+
+    assert output_file.exists()
+
+    tree = ET.parse(output_file)
+    root = tree.getroot()
+
+    meter_widgets = root.findall(".//widget[@class='PyDMAnalogIndicator']")
+    assert len(meter_widgets) == 1, "Should have one PyDMAnalogIndicator"
+
+    widget = meter_widgets[0]
+
+    channel_prop = widget.find("property[@name='channel']")
+    assert channel_prop is not None, "Widget should have channel property"
+    assert channel_prop.find("string").text == "IOC:SYS0:PRESSURE"
+
+    show_ticks = widget.find("property[@name='showTicks']")
+    assert show_ticks is not None, "Widget should have showTicks property"
+    assert show_ticks.find("bool").text == "true"
+
+    show_limits = widget.find("property[@name='showLimits']")
+    assert show_limits is not None, "Widget should have showLimits property"
+    assert show_limits.find("bool").text == "true"
+
+    show_units = widget.find("property[@name='showUnits']")
+    assert show_units is not None, "Widget should have showUnits property"
+    assert show_units.find("bool").text == "true"

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -21,6 +21,7 @@ from pydmconverter.widgets import (
     PyDMDrawingLine,
     PyDMDrawingPolyline,
     PyDMWaveformPlot,
+    PyDMAnalogIndicator,
 )
 
 from pydmconverter.widgets_helpers import XMLSerializableMixin, Alarmable, Drawable, Hidable
@@ -612,3 +613,40 @@ def test_waveformplot_no_limits_enables_autorange():
     properties = widget.generate_properties()
     yaxes_prop = next((p for p in properties if p.get("name") == "yAxes"), None)
     assert yaxes_prop is None
+
+
+# --- Tests for PyDMAnalogIndicator ---
+
+
+def test_pydmanalogindicator_generate_properties():
+    widget = PyDMAnalogIndicator(
+        showTicks=True,
+        showLimits=True,
+        showUnits=True,
+        showValue=True,
+        precision=2,
+        indicatorColor=(255, 0, 0, 255),
+        background_color=(200, 200, 200, 255),
+        foreground_color=(0, 0, 0, 255),
+        channel="ca://IOC:SYS0:PRESSURE",
+    )
+    properties: List[ET.Element] = widget.generate_properties()
+    prop_dict = {prop.get("name"): get_property_value(prop) for prop in properties}
+
+    assert prop_dict.get("showTicks") == "true"
+    assert prop_dict.get("showLimits") == "true"
+    assert prop_dict.get("showUnits") == "true"
+    assert prop_dict.get("showValue") == "true"
+    assert prop_dict.get("precision") == "2"
+    assert prop_dict.get("channel") == "ca://IOC:SYS0:PRESSURE"
+
+
+def test_pydmanalogindicator_defaults():
+    widget = PyDMAnalogIndicator()
+    properties: List[ET.Element] = widget.generate_properties()
+    prop_dict = {prop.get("name"): get_property_value(prop) for prop in properties}
+
+    assert "showTicks" not in prop_dict
+    assert "showLimits" not in prop_dict
+    assert "showUnits" not in prop_dict
+    assert "precision" not in prop_dict


### PR DESCRIPTION
## Description 
Adds conversion support for EDM meter/activeMeterClass widgets to PyDMAnalogIndicator.
Maps readPv to channel, showScale to showTicks/showLimits/showUnits, and handles
barColor/scaleColor conversion.

Closes #125