### PR TITLE
FIX: Normalize visMin/visMax values to prevent SyntaxError in converted .ui files

### DIFF
--- a/pydmconverter/custom_types.py
+++ b/pydmconverter/custom_types.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional, Union
 
 
 @dataclass(frozen=True)
@@ -24,8 +25,8 @@ class RuleArguments:
     channel: str
     show_on_true: bool
     initial_value: bool
-    visMin: int
-    visMax: int
+    visMin: Optional[Union[int, float, str]]
+    visMax: Optional[Union[int, float, str]]
 
     def __iter__(self):
         yield self.rule_type

--- a/pydmconverter/widgets_helpers.py
+++ b/pydmconverter/widgets_helpers.py
@@ -906,8 +906,8 @@ class BoolRule(XMLConvertible):
     channel: str
     initial_value: Optional[bool] = True
     show_on_true: Optional[bool] = True
-    visMin: Optional[int] = None
-    visMax: Optional[int] = None
+    visMin: Optional[Union[int, float, str]] = None
+    visMax: Optional[Union[int, float, str]] = None
     notes: Optional[str] = ""
 
     def to_string(self):
@@ -920,8 +920,14 @@ class BoolRule(XMLConvertible):
             A string representing the rule.
         """
         if self.visMin is not None and self.visMax is not None:
-            show_on_true_string = f"True if float(ch[0]) >= {self.visMin} and float(ch[0]) < {self.visMax} else False"
-            show_on_false_string = f"False if float(ch[0]) >= {self.visMin} and float(ch[0]) < {self.visMax} else True"
+            try:
+                vis_min = float(self.visMin)
+                vis_max = float(self.visMax)
+            except (ValueError, TypeError):
+                vis_min = 0.0
+                vis_max = 0.0
+            show_on_true_string = f"True if float(ch[0]) >= {vis_min} and float(ch[0]) < {vis_max} else False"
+            show_on_false_string = f"False if float(ch[0]) >= {vis_min} and float(ch[0]) < {vis_max} else True"
         else:
             show_on_true_string = "True if ch[0]==1 else False"
             show_on_false_string = "True if ch[0]!=1 else False"
@@ -1047,8 +1053,14 @@ class MultiRule(XMLConvertible):
         ch = f"ch[{index}]"
 
         if visMin is not None and visMax is not None:
-            show_on_true_string = f"float({ch}) >= {visMin} and float({ch}) < {visMax}"
-            show_on_false_string = f"float({ch}) < {visMin} or float({ch}) >= {visMax}"
+            try:
+                vis_min = float(visMin)
+                vis_max = float(visMax)
+            except (ValueError, TypeError):
+                vis_min = 0.0
+                vis_max = 0.0
+            show_on_true_string = f"float({ch}) >= {vis_min} and float({ch}) < {vis_max}"
+            show_on_false_string = f"float({ch}) < {vis_min} or float({ch}) >= {vis_max}"
         else:
             show_on_true_string = f"{ch}==1"
             show_on_false_string = f"{ch}!=1"  # TODO: maybe need to change from specifically 1 (== 0 or != 0)?
@@ -1647,8 +1659,8 @@ class Controllable(Tangible):
     visPv: Optional[str] = None
     visInvert: Optional[bool] = None
     rules: Optional[List[str]] = field(default_factory=list)
-    visMin: Optional[int] = None
-    visMax: Optional[int] = None
+    visMin: Optional[Union[int, float, str]] = None
+    visMax: Optional[Union[int, float, str]] = None
     text = None
     hide_on_disconnect_channel: Optional[str] = None
     isSymbol: Optional[bool] = None

--- a/tests/test_widgets_helpers.py
+++ b/tests/test_widgets_helpers.py
@@ -31,6 +31,8 @@ from pydmconverter.widgets_helpers import (
     SizePolicy,
     StyleSheet,
     Text,
+    BoolRule,
+    MultiRule,
 )
 
 
@@ -629,3 +631,57 @@ def testBrush():
     )
     brush = Brush(50, 100, 150, fill=False)
     assert target == brush.to_string()
+
+
+class TestBoolRuleExpression:
+    def test_string_integer_values(self):
+        rule = BoolRule("Visible", "TEST:PV", visMin="0", visMax="1")
+        result = rule.to_string()
+        assert "float(ch[0]) >= 0.0 and float(ch[0]) < 1.0" in result
+
+    def test_string_float_values(self):
+        rule = BoolRule("Visible", "TEST:PV", visMin="0.5", visMax="10.5")
+        result = rule.to_string()
+        assert "float(ch[0]) >= 0.5 and float(ch[0]) < 10.5" in result
+
+    def test_scientific_notation_values(self):
+        rule = BoolRule("Visible", "TEST:PV", visMin="1e+02", visMax="2.5e+03")
+        result = rule.to_string()
+        assert "float(ch[0]) >= 100.0 and float(ch[0]) < 2500.0" in result
+
+    def test_no_vis_min_max(self):
+        rule = BoolRule("Visible", "TEST:PV")
+        result = rule.to_string()
+        assert "ch[0]==1" in result
+
+    def test_show_on_false(self):
+        rule = BoolRule("Visible", "TEST:PV", show_on_true=False, visMin="0", visMax="1")
+        result = rule.to_string()
+        assert "False if float(ch[0]) >= 0.0 and float(ch[0]) < 1.0 else True" in result
+
+
+class TestMultiRuleExpression:
+    def test_string_integer_values(self):
+        rule = MultiRule("Visible", [])
+        result = rule.get_expression(0, True, "0", "1", None)
+        assert result == "float(ch[0]) >= 0.0 and float(ch[0]) < 1.0"
+
+    def test_string_float_values(self):
+        rule = MultiRule("Visible", [])
+        result = rule.get_expression(0, True, "0.5", "10.5", None)
+        assert result == "float(ch[0]) >= 0.5 and float(ch[0]) < 10.5"
+
+    def test_scientific_notation_values(self):
+        rule = MultiRule("Visible", [])
+        result = rule.get_expression(0, True, "1e+02", "2.5e+03", None)
+        assert result == "float(ch[0]) >= 100.0 and float(ch[0]) < 2500.0"
+
+    def test_show_on_false(self):
+        rule = MultiRule("Visible", [])
+        result = rule.get_expression(0, False, "0", "1", None)
+        assert result == "float(ch[0]) < 0.0 or float(ch[0]) >= 1.0"
+
+    def test_no_vis_min_max(self):
+        rule = MultiRule("Visible", [])
+        result = rule.get_expression(0, True, None, None, None)
+        assert result == "ch[0]==1"


### PR DESCRIPTION
## Description 
- EDM parser reads visMin/visMax as strings (e.g. "1e+02", "2e"). These were
  interpolated directly into Python expression strings in .ui rules, producing
  invalid syntax like `float(ch[0]) >= 2e` when opened with PyDM.
- Convert visMin/visMax to float before interpolation, normalizing values to
  valid decimal literals (e.g. "1e+02" → 100.0).
- Added error handling matching the existing Integer.to_xml() pattern.
- Fixed type hints for visMin/visMax across BoolRule, Controllable, and
  RuleArguments (were `int`, actually receive `str`).

closes #127 