### PR TITLE
FIX: SyntaxError from digit-leading widget names in generated .ui files

### DIFF
--- a/pydmconverter/edm/converter_helpers.py
+++ b/pydmconverter/edm/converter_helpers.py
@@ -1078,6 +1078,8 @@ def populate_tab_bar(obj: EDMObject, widget):
         file_list = obj.properties["displayFileName"]
         for index, tab_name in enumerate(tab_names):
             widget_name = re.sub(r"[^a-zA-Z0-9_]", "_", tab_name)
+            if widget_name and widget_name[0].isdigit():
+                widget_name = f"tab_{widget_name}"
             child_widget = QWidget(title=tab_name)
             widget.add_child(child_widget)
             embedded_widget = PyDMEmbeddedDisplay(

--- a/pydmconverter/widgets_helpers.py
+++ b/pydmconverter/widgets_helpers.py
@@ -91,6 +91,8 @@ class XMLSerializableMixin(XMLConvertible):
         """
         if not self.name:
             self.name = f"{type(self).__name__}{type(self).count}"
+        elif self.name[0].isdigit():
+            self.name = f"widget_{self.name}"
         type(self).count += 1
 
     def generate_properties(self) -> List[etree.Element]:


### PR DESCRIPTION
## Description 
- Numeric EDM tab names (e.g., "1408") produced widget names like
  `1408_embedded` in the .ui output, causing `SyntaxError: invalid
  decimal literal` when PyDM compiled the UI to Python
- Prefix digit-leading names with `tab_` in `populate_tab_bar()` and
  add a safety net in `XMLSerializableMixin.__post_init__` for any
  other code path