### PR TITLE
FIX: propagate group visInvert to child widget visibility rules (#132)

### DIFF
--- a/pydmconverter/edm/converter_helpers.py
+++ b/pydmconverter/edm/converter_helpers.py
@@ -750,9 +750,7 @@ def traverse_group(
 
             vis_invert = bool(obj.properties.get("visInvert", False))
             if "visPv" in obj.properties and "visMin" in obj.properties and "visMax" in obj.properties:
-                curr_vispv = [
-                    (obj.properties["visPv"], obj.properties["visMin"], obj.properties["visMax"], vis_invert)
-                ]
+                curr_vispv = [(obj.properties["visPv"], obj.properties["visMin"], obj.properties["visMax"], vis_invert)]
             elif "visPv" in obj.properties:
                 curr_vispv = [(obj.properties["visPv"], None, None, vis_invert)]
             else:

--- a/pydmconverter/edm/converter_helpers.py
+++ b/pydmconverter/edm/converter_helpers.py
@@ -720,7 +720,7 @@ def traverse_group(
     offset_x: float = 0,
     offset_y: float = 0,
     central_widget: EDMGroup = None,
-    parent_vispvs: Optional[List[Tuple[str, int, int]]] = None,
+    parent_vispvs: Optional[List[Tuple[str, int, int, bool]]] = None,
 ):
     """
     Recursively traverse an EDM group and convert each object to a PyDM widget.
@@ -748,16 +748,24 @@ def traverse_group(
 
             logger.debug("Skipped pydm_group")
 
+            vis_invert = bool(obj.properties.get("visInvert", False))
             if "visPv" in obj.properties and "visMin" in obj.properties and "visMax" in obj.properties:
-                curr_vispv = [(obj.properties["visPv"], obj.properties["visMin"], obj.properties["visMax"])]
+                curr_vispv = [
+                    (obj.properties["visPv"], obj.properties["visMin"], obj.properties["visMax"], vis_invert)
+                ]
             elif "visPv" in obj.properties:
-                curr_vispv = [(obj.properties["visPv"], None, None)]
+                curr_vispv = [(obj.properties["visPv"], None, None, vis_invert)]
             else:
                 curr_vispv = []
 
             if "symbolMin" in obj.properties and "symbolMax" in obj.properties and "symbolChannel" in obj.properties:
                 symbol_vispv = [
-                    (obj.properties["symbolChannel"], obj.properties["symbolMin"], obj.properties["symbolMax"])
+                    (
+                        obj.properties["symbolChannel"],
+                        obj.properties["symbolMin"],
+                        obj.properties["symbolMax"],
+                        False,
+                    )
                 ]
             else:
                 symbol_vispv = []

--- a/pydmconverter/widgets_helpers.py
+++ b/pydmconverter/widgets_helpers.py
@@ -1655,7 +1655,7 @@ class Controllable(Tangible):
 
     channel: Optional[str] = None
     pydm_tool_tip: Optional[str] = None
-    visPvList: Optional[List[Tuple[str, int, int]]] = None
+    visPvList: Optional[List[Tuple[str, int, int, bool]]] = None
     visPv: Optional[str] = None
     visInvert: Optional[bool] = None
     rules: Optional[List[str]] = field(default_factory=list)
@@ -1687,13 +1687,17 @@ class Controllable(Tangible):
             properties.append(PyDMToolTip(self.pydm_tool_tip).to_xml())
         if self.visPvList is not None:
             for elem in self.visPvList:
-                group_channel, group_min, group_max = elem
+                if len(elem) == 4:
+                    group_channel, group_min, group_max, group_invert = elem
+                else:
+                    group_channel, group_min, group_max = elem
+                    group_invert = False
                 self.rules.append(
                     RuleArguments(
                         "Visible",
                         group_channel,
                         False,
-                        not self.visInvert if self.visInvert is not None else True,
+                        not group_invert,
                         group_min,
                         group_max,
                     )


### PR DESCRIPTION
## Description 
Child widgets inside a group with `visInvert=True` had their
visibility rules inverted, hiding the wrong elements (e.g. EnumButton arrows)

Closes #132. 