### PR TITLE
Fix calc.list lookup and stop aborting conversions on bad CALC and LOC PVs

### DIFF
--- a/pydmconverter/__main__.py
+++ b/pydmconverter/__main__.py
@@ -29,7 +29,7 @@ def run_gui() -> None:
     subprocess.run(["bash", str(launch_script)], check=True)
 
 
-def run(input_file, output_file, input_file_type=".edl", override=False, scrollable=False, site=None):
+def run(input_file, output_file, input_file_type=".edl", override=False, scrollable=False, site=None, calc_list=None):
     input_path: Path = Path(input_file)
     output_path: Path = Path(output_file)
 
@@ -39,7 +39,7 @@ def run(input_file, output_file, input_file_type=".edl", override=False, scrolla
         if output_path.is_file() and not override:
             raise FileExistsError(f"Output file '{output_path}' already exists. Use --override or -o to overwrite it.")
         copy_img_files(input_path.parent, output_path.parent)
-        convert(str(input_path), str(output_path), scrollable, site=site)
+        convert(str(input_path), str(output_path), scrollable, site=site, calc_list_file=calc_list)
     else:
         if input_file_type[0] != ".":  # prepending . so it will not pick up other file types with same suffix
             input_file_type = "." + input_file_type
@@ -47,7 +47,7 @@ def run(input_file, output_file, input_file_type=".edl", override=False, scrolla
         files_found: int
         files_failed: list[str]
         files_found, files_failed = convert_files_in_folder(
-            input_path, output_path, input_file_type, override, scrollable, site=site
+            input_path, output_path, input_file_type, override, scrollable, site=site, calc_list=calc_list
         )
 
         if files_found == 0:
@@ -77,7 +77,8 @@ def run_cli(args: argparse.Namespace) -> None:
     override: bool = args.override
     scrollable: bool = args.scrollable
     site: str = args.site
-    run(input_file, output_file, input_file_type, override, scrollable, site=site)
+    calc_list: str = args.calc_list
+    run(input_file, output_file, input_file_type, override, scrollable, site=site, calc_list=calc_list)
 
 
 """
@@ -126,7 +127,13 @@ def copy_img_files(input_path: Path, output_path: Path) -> None:
 
 
 def convert_files_in_folder(
-    input_path: Path, output_path: Path, input_file_type: str, override: bool, scrollable: bool, site=None
+    input_path: Path,
+    output_path: Path,
+    input_file_type: str,
+    override: bool,
+    scrollable: bool,
+    site=None,
+    calc_list=None,
 ) -> tuple[int, list[str]]:
     """Recursively runs convert on files in directory and subdirectories
 
@@ -162,7 +169,7 @@ def convert_files_in_folder(
             logging.warning(f"Skipped: {output_file_path} already exists. Use --override or -o to overwrite it.")
         else:
             try:
-                convert(file, output_file_path, scrollable, site=site)
+                convert(file, output_file_path, scrollable, site=site, calc_list_file=calc_list)
             except Exception as e:
                 files_failed.append(str(file))
                 logging.warning(f"Failed to convert {file}: {e}")
@@ -171,7 +178,7 @@ def convert_files_in_folder(
     subdirectories = [item for item in input_path.iterdir() if item.is_dir()]
     for subdir in subdirectories:
         sub_found, sub_failed = convert_files_in_folder(
-            subdir, output_path / subdir.name, input_file_type, override, scrollable, site=site
+            subdir, output_path / subdir.name, input_file_type, override, scrollable, site=site, calc_list=calc_list
         )
         files_found += sub_found
         files_failed += sub_failed
@@ -232,6 +239,12 @@ def main() -> None:
         type=str,
         default=None,
         help="Apply site-specific conversion rules (e.g., slac)",
+    )
+    parser.add_argument(
+        "--calc-list",
+        type=str,
+        default=None,
+        help="Path to an EDM calc.list file used to resolve named CALC PVs",
     )
     args: argparse.Namespace = parser.parse_args()
 

--- a/pydmconverter/edm/converter.py
+++ b/pydmconverter/edm/converter.py
@@ -51,9 +51,9 @@ CUSTOM_WIDGET_DEFINITIONS = {
 }
 
 
-def convert(input_path, output_path, scrollable=False, site=None):
+def convert(input_path, output_path, scrollable=False, site=None, calc_list_file=None):
     try:
-        edm_parser = EDMFileParser(input_path, output_path)
+        edm_parser = EDMFileParser(input_path, output_path, calc_list_file=calc_list_file)
         logger.info(f"Successfully parsed EDM file: {input_path}")
     except FileNotFoundError:
         logger.error("File Not Found")

--- a/pydmconverter/edm/parser.py
+++ b/pydmconverter/edm/parser.py
@@ -60,18 +60,21 @@ class EDMFileParser:
     #    re.DOTALL | re.MULTILINE,
     # )
 
-    def __init__(self, file_path: str | Path, output_file_path: str | Path):
+    def __init__(self, file_path: str | Path, output_file_path: str | Path, calc_list_file: str | None = None):
         """Creates an instance of EDMFileParser for the given file_path
 
         Parameters
         ----------
         file_path : str | Path
             EDM file to parse
+        calc_list_file : str, optional
+            Explicit path to a calc.list file used to resolve named CALC PVs
         """
         if not Path(file_path).exists():
             raise FileNotFoundError(f"File not found: {file_path}")
         self.file_path = file_path
         self.output_file_path = output_file_path
+        self.calc_list_file = calc_list_file
 
         try:
             with open(file_path, "r") as file:
@@ -97,7 +100,7 @@ class EDMFileParser:
         )  # remove global macros TODO: In edm, these macros (!W) and (!A) are used to specify the scope of the macros (outside of a specific screen) this may need to be resolved more cleanly later
         pattern = r"\\*\$\(([^)]+)\)"
         self.text = re.sub(pattern, r"${\1}", self.text)
-        self.text, _, _ = replace_calc_and_loc_in_edm_content(self.text, file_path)
+        self.text, _, _ = replace_calc_and_loc_in_edm_content(self.text, file_path, self.calc_list_file)
         return self.text
 
     def parse_screen_properties(self) -> None:

--- a/pydmconverter/edm/parser_helpers.py
+++ b/pydmconverter/edm/parser_helpers.py
@@ -7,36 +7,46 @@ from pydmconverter.custom_types import RGBA
 logger = logging.getLogger(__name__)
 
 
-def search_calc_list(file_path: str) -> str:
+def search_calc_list(file_path: str, cli_calc_file: Optional[str] = None) -> Optional[str]:
     """
-    search for a calc.list file and return the path if found, returns None if no calc.list exists.
+    Search for a calc.list file and return its full path, returns None if no calc.list is found.
 
-    This function reads a file, filters out comment lines (lines starting with
-    '#') and empty lines, and assumes each definition in the file is specified
-    by two consecutive non-comment lines:
+    The search checks the following locations in order:
+
+    1. cli_calc_file, if provided.
+    2. calc.list in the same directory as file_path.
+    3. calc.list in a config subdirectory next to file_path.
+    4. $EDMFILES/calc.list.
 
     Parameters
     ----------
     file_path : str
         The path to a file whose directory will be searched for 'calc.list'.
+    cli_calc_file : str, optional
+        An explicit path to a calc.list file (e.g. from the --calc-list CLI
+        option). If provided and valid, it overrides the other locations.
 
     Returns
     -------
     Optional[str]
-        The full path to the found 'calc.list' file, in either the local directory or in $EDMFILES, as a string if it exists;
-        otherwise, None.
+        The full path to the found 'calc.list' file if it exists; otherwise, None.
     """
-    directory = os.path.dirname(file_path)
-    local_calc_list = os.path.join(directory, "calc.list")
+    if cli_calc_file and os.path.isfile(cli_calc_file):
+        return cli_calc_file
 
-    if os.path.isfile(local_calc_list):
-        return directory
+    directory = os.path.dirname(file_path)
+    candidates = [
+        os.path.join(directory, "calc.list"),
+        os.path.join(directory, "config", "calc.list"),
+    ]
 
     edmfiles = os.environ.get("EDMFILES", "")
-    global_calc_list = os.path.join(edmfiles, "calc.list")
+    if edmfiles:
+        candidates.append(os.path.join(edmfiles, "calc.list"))
 
-    if edmfiles and os.path.isfile(global_calc_list):
-        return global_calc_list
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
 
     return None
 
@@ -441,9 +451,13 @@ def loc_conversion(edm_string: str) -> str:
                 value = type_and_value
                 type_char = "d"
             except ValueError:
-                # print("Invalid EDM format: Missing ':' separator and not an integer (enter c to continue)")
-                logger.debug(f"name: {name}, value: {type_and_value}")
-                raise ValueError("Invalid EDM format: Missing ':' separator and not an integer")
+                # EDM falls back to a string PV with an empty value when the
+                # initialization is unparseable, so mirror that behavior here.
+                logger.warning(
+                    f"Unparseable local PV initialization '{type_and_value}' for '{name}', defaulting to an empty string"
+                )
+                value = ""
+                type_char = "s"
 
     edm_type = type_char.lower()
     if edm_type.isdigit():
@@ -480,7 +494,7 @@ def loc_conversion(edm_string: str) -> str:
 
 
 def replace_calc_and_loc_in_edm_content(
-    edm_content: str, filepath: str
+    edm_content: str, filepath: str, calc_list_file: Optional[str] = None
 ) -> Tuple[str, Dict[str, Dict[str, str]], Dict[str, Dict[str, str]]]:
     """
     Replace both CALC\\...(...) and LOC\\...=... references in the EDM file content
@@ -493,6 +507,9 @@ def replace_calc_and_loc_in_edm_content(
         The full text of the EDM file, as a single string.
     filepath : str
         path of the given edm file
+    calc_list_file : str, optional
+        An explicit path to a calc.list file used to resolve named CALC PVs.
+        Overrides the default calc.list search locations.
 
     Returns
     -------
@@ -505,7 +522,7 @@ def replace_calc_and_loc_in_edm_content(
         A dictionary of all encountered LOC references, similarly mapping each
         unique original LOC reference to "full" and "short" addresses.
     """
-    calc_list_path = search_calc_list(filepath)
+    calc_list_path = search_calc_list(filepath, calc_list_file)
     calc_dict = parse_calc_list(calc_list_path)
 
     encountered_calcs: Dict[str, Dict[str, str]] = {}
@@ -516,7 +533,13 @@ def replace_calc_and_loc_in_edm_content(
     def replace_calc_match(match: re.Match) -> str:
         edm_pv = match.group(1)
         if edm_pv not in encountered_calcs:
-            full_url = translate_calc_pv_to_pydm(edm_pv, calc_dict=calc_dict)
+            try:
+                full_url = translate_calc_pv_to_pydm(edm_pv, calc_dict=calc_dict)
+            except ValueError as e:
+                # Leave the original EDM reference in place so one bad calc
+                # does not abort the conversion of the whole file.
+                logger.warning(f"Could not translate CALC PV '{edm_pv}': {e}")
+                return match.group(0)
             short_url = full_url.split("?", 1)[0]
             encountered_calcs[edm_pv] = {"full": full_url, "short": short_url}
             return full_url
@@ -536,7 +559,13 @@ def replace_calc_and_loc_in_edm_content(
                 full_url = f"loc://{cleaned_pv}"
                 short_url = full_url
             else:
-                full_url = loc_conversion(edm_pv)  # TODO: remove the ifs later
+                try:
+                    full_url = loc_conversion(edm_pv)  # TODO: remove the ifs later
+                except (ValueError, NotImplementedError) as e:
+                    # Leave the original EDM reference in place so one bad
+                    # local PV does not abort the conversion of the whole file.
+                    logger.warning(f"Could not translate LOC PV '{edm_pv}': {e}")
+                    return match.group(0)
                 if full_url:
                     short_url = full_url.split("?", 1)[0]
                 else:

--- a/tests/edm/test_parser_helpers.py
+++ b/tests/edm/test_parser_helpers.py
@@ -19,8 +19,9 @@ from pydmconverter.edm.parser_helpers import (
 
 def test_search_calc_list(tmp_path, monkeypatch):
     """
-    Test that search_calc_list returns the local directory if calc.list
-    exists there, otherwise checks EDMFILES.
+    Test that search_calc_list returns the full path to calc.list, checking
+    the explicit cli path, the local directory, a local config subdirectory,
+    and EDMFILES in that order.
     """
     fake_file = tmp_path / "fake.edl"
     fake_file.touch()
@@ -29,9 +30,26 @@ def test_search_calc_list(tmp_path, monkeypatch):
     local_calc_list.touch()
 
     result = search_calc_list(str(fake_file))
-    assert result == str(tmp_path), "Expected to find local calc.list in the directory."
+    assert result == str(local_calc_list), "Expected the full path of the local calc.list."
+
+    cli_calc_dir = tmp_path / "cli"
+    cli_calc_dir.mkdir()
+    cli_calc_list = cli_calc_dir / "calc.list"
+    cli_calc_list.touch()
+
+    result = search_calc_list(str(fake_file), cli_calc_file=str(cli_calc_list))
+    assert result == str(cli_calc_list), "Expected the cli path to override other locations."
 
     local_calc_list.unlink()
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    config_calc_list = config_dir / "calc.list"
+    config_calc_list.touch()
+
+    result = search_calc_list(str(fake_file))
+    assert result == str(config_calc_list), "Expected to find calc.list in the local config subdirectory."
+
+    config_calc_list.unlink()
     global_calc_dir = tempfile.mkdtemp()
     global_calc_list = os.path.join(global_calc_dir, "calc.list")
     with open(global_calc_list, "w") as f:
@@ -174,6 +192,12 @@ def test_loc_conversion():
     result_no_colon = loc_conversion(edm_string_missing_colon)
     assert "loc://noColon" in result_no_colon, f"Expected loc://noColon in result, got '{result_no_colon}'"
 
+    # An unparseable initialization falls back to a string PV with an empty
+    # value, matching EDM behavior
+    edm_string_unparseable = "LOC\\myLocal=intPv=ShowChannels"
+    result_unparseable = loc_conversion(edm_string_unparseable)
+    assert result_unparseable == "loc://myLocal?type=str&init="
+
 
 @pytest.mark.parametrize(
     "edm_content",
@@ -241,7 +265,7 @@ def test_replace_calc_and_loc_in_edm_content(
         edm_content, filepath="/some/fake/edm_file.edl"
     )
 
-    mock_search_calc_list.assert_called_once_with("/some/fake/edm_file.edl")
+    mock_search_calc_list.assert_called_once_with("/some/fake/edm_file.edl", None)
     mock_parse_calc_list.assert_called_once_with("/fake/path/calc.list")
 
     assert "calc://sum?A=channel://pv1&B=channel://pv2&expr=A+B" in new_content
@@ -271,6 +295,48 @@ def test_replace_calc_and_loc_in_edm_content(
     myLocalInt_entry = encountered_locs["LOC\\myLocalInt=i:42"]
     assert myLocalInt_entry["full"] == "loc://myLocalInt?type=int&init=42"
     assert myLocalInt_entry["short"] == "loc://myLocalInt"
+
+
+def test_replace_calc_keeps_undefined_calc(tmp_path):
+    """
+    Tests that an undefined named calc is left untouched with a warning
+    instead of aborting the conversion of the whole file.
+    """
+    edm_content = """
+    object activeXTextClass {
+      controlPv "CALC\\\\noSuchCalc(pv1)"
+      visPv "LOC\\myLocal=d:3.14"
+    }
+    """
+    fake_file = tmp_path / "fake.edl"
+    fake_file.touch()
+
+    new_content, encountered_calcs, encountered_locs = replace_calc_and_loc_in_edm_content(
+        edm_content, filepath=str(fake_file)
+    )
+
+    assert "CALC\\\\noSuchCalc(pv1)" in new_content, "Expected the unresolved CALC PV to be left as is."
+    assert encountered_calcs == {}
+    assert "loc://myLocal?type=float&init=3.14" in new_content, "Expected LOC replacement to still happen."
+
+
+def test_replace_calc_uses_explicit_calc_list(tmp_path):
+    """
+    Tests that an explicit calc_list_file is used to resolve named calcs.
+    """
+    calc_list_file = tmp_path / "mycalcs.list"
+    calc_list_file.write_text("CALC1\nsum\nA+B\n")
+
+    edm_content = 'controlPv "CALC\\\\sum(pv1, pv2)"'
+    fake_file = tmp_path / "fake.edl"
+    fake_file.touch()
+
+    new_content, encountered_calcs, _ = replace_calc_and_loc_in_edm_content(
+        edm_content, filepath=str(fake_file), calc_list_file=str(calc_list_file)
+    )
+
+    assert "calc://sum?A=ca://pv1&B=ca://pv2&expr=A+B" in new_content
+    assert "CALC\\\\sum(pv1, pv2)" in encountered_calcs
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- search_calc_list returned the directory instead of the file path when a calc.list sat next to the .edl file, so local calc.list files were silently ignored and every named calc raised ValueError: Calculation 'X' is not defined in calc_dict
- The search now returns the full path and also checks a config subdirectory next to the .edl file, which is where SLAC screen repos keep it (e.g. bcs/config/calc.list)
- Added a --calc-list CLI option to point the converter at any calc.list explicitly, mirroring the existing EDM color file override
- An undefined calc now logs a warning and leaves the original EDM reference in place instead of failing the whole file
- Malformed local PV initializations (e.g. LOC\pv=intPv=ShowChannels in BCS_Zone_3_Input.edl) now fall back to a string PV with an empty value, matching EDM's own fallback, instead of raising

## Testing

- All three files reported in the issues (BCS_BSY.edl, BCS_BSY_136DTC.edl, BCS_Zone_3_Input.edl) now convert successfully with no flags or env vars set
- Full test suite passes (144 passed), pre-commit clean
- New tests cover the search order, the --calc-list override, the undefined calc warning path, and the local PV fallback

Fixes #131
Fixes #135