### PR TITLE
Convert EDM meter labels to the PyDMAnalogIndicator title property

### DIFF
--- a/pydmconverter/edm/converter_helpers.py
+++ b/pydmconverter/edm/converter_helpers.py
@@ -707,6 +707,17 @@ def apply_widget_post_processing(
         widget.showLimits = True
         widget.showUnits = True
 
+    # EDM meter labels become the analog indicator title. pvName and pvLabel
+    # types resolve from the PV at runtime, so use the PV name for those.
+    if isinstance(widget, PyDMAnalogIndicator):
+        label_type = obj.properties.get("labelType", "literal")
+        if label_type == "literal":
+            title = obj.properties.get("label")
+        else:
+            title = obj.properties.get("readPv")
+        if title:
+            widget.title = title
+
 
 def traverse_group(
     edm_group: EDMGroup,

--- a/pydmconverter/widgets.py
+++ b/pydmconverter/widgets.py
@@ -1865,10 +1865,13 @@ class PyDMAnalogIndicator(Alarmable):
     indicatorColor: Optional[RGBA] = None
     background_color: Optional[RGBA] = None
     foreground_color: Optional[RGBA] = None
+    title: Optional[str] = None
 
     def generate_properties(self) -> List[ET.Element]:
         properties: List[ET.Element] = super().generate_properties()
 
+        if self.title is not None:
+            properties.append(Str("title", self.title).to_xml())
         if self.showTicks is not None:
             properties.append(Bool("showTicks", self.showTicks).to_xml())
         if self.showLimits is not None:

--- a/tests/edm/test_converter.py
+++ b/tests/edm/test_converter.py
@@ -375,6 +375,23 @@ def test_convert_meter_widget(tmp_path):
         scaleMin 0
         scaleMax 100
         showScale
+        label "Pressure"
+        fgColor index 14
+        bgColor index 0
+        endObjectProperties
+
+        # (Meter)
+        object activeMeterClass
+        beginObjectProperties
+        major 4
+        minor 0
+        release 1
+        x 300
+        y 100
+        w 150
+        h 150
+        readPv "IOC:SYS0:FLOW"
+        labelType "pvName"
         fgColor index 14
         bgColor index 0
         endObjectProperties
@@ -392,13 +409,22 @@ def test_convert_meter_widget(tmp_path):
     root = tree.getroot()
 
     meter_widgets = root.findall(".//widget[@class='PyDMAnalogIndicator']")
-    assert len(meter_widgets) == 1, "Should have one PyDMAnalogIndicator"
+    assert len(meter_widgets) == 2, "Should have two PyDMAnalogIndicators"
 
     widget = meter_widgets[0]
 
     channel_prop = widget.find("property[@name='channel']")
     assert channel_prop is not None, "Widget should have channel property"
     assert channel_prop.find("string").text == "IOC:SYS0:PRESSURE"
+
+    title_prop = widget.find("property[@name='title']")
+    assert title_prop is not None, "Widget should have title property"
+    assert title_prop.find("string").text == "Pressure"
+
+    pv_name_widget = meter_widgets[1]
+    pv_name_title = pv_name_widget.find("property[@name='title']")
+    assert pv_name_title is not None, "labelType pvName should fall back to the PV name as title"
+    assert pv_name_title.find("string").text == "IOC:SYS0:FLOW"
 
     show_ticks = widget.find("property[@name='showTicks']")
     assert show_ticks is not None, "Widget should have showTicks property"

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -629,6 +629,7 @@ def test_pydmanalogindicator_generate_properties():
         background_color=(200, 200, 200, 255),
         foreground_color=(0, 0, 0, 255),
         channel="ca://IOC:SYS0:PRESSURE",
+        title="Pressure",
     )
     properties: List[ET.Element] = widget.generate_properties()
     prop_dict = {prop.get("name"): get_property_value(prop) for prop in properties}
@@ -639,6 +640,7 @@ def test_pydmanalogindicator_generate_properties():
     assert prop_dict.get("showValue") == "true"
     assert prop_dict.get("precision") == "2"
     assert prop_dict.get("channel") == "ca://IOC:SYS0:PRESSURE"
+    assert prop_dict.get("title") == "Pressure"
 
 
 def test_pydmanalogindicator_defaults():
@@ -650,3 +652,4 @@ def test_pydmanalogindicator_defaults():
     assert "showLimits" not in prop_dict
     assert "showUnits" not in prop_dict
     assert "precision" not in prop_dict
+    assert "title" not in prop_dict


### PR DESCRIPTION
## Summary

- PyDM now supports a title property on PyDMAnalogIndicator (slaclab/pydm#1330), but the converter dropped EDM meter labels entirely
- The converter PyDMAnalogIndicator widget now emits a title string property
- EDM activeMeterClass labels map to the title: labelType literal (the default) uses the label text, labelType pvName and pvLabel fall back to the readPv name since those are resolved from the live PV at runtime

## Testing

- Unit tests for the title property emission and both labelType paths
- Verified on real screens: Archive/misc-orig/ams_fast_6x6.edl (literal labels) and Archive/klys-rig/genesys_ps.edl (pvLabel meters) both convert with correct titles
- Full test suite passes, pre-commit clean

Fixes #126