### PR TITLE
Add an overwrite existing files option to the GUI

### DIFF
--- a/app/src/model/options_model.py
+++ b/app/src/model/options_model.py
@@ -13,6 +13,7 @@ class OptionsModel:
     def __init__(self):
         # General options
         self.output_folder = None
+        self.override_existing = False
 
         # EDM options
         self.edm_override_def_colors = False
@@ -39,6 +40,9 @@ class OptionsModel:
                 output_folder = data.get("output_folder", None)
                 if output_folder is not None and os.path.exists(output_folder):
                     self.output_folder = output_folder
+                override_existing = data.get("override_existing", None)
+                if override_existing is not None:
+                    self.override_existing = override_existing
 
                 # EDM options
                 edm_override_def_colors = data.get("edm_override_def_colors", None)
@@ -61,6 +65,8 @@ class OptionsModel:
         # General options
         if self.output_folder is not None:
             data["output_folder"] = self.output_folder
+        if self.override_existing is not False:
+            data["override_existing"] = self.override_existing
 
         # EDM options
         if self.edm_override_def_colors is not False:

--- a/app/src/view/main_window.py
+++ b/app/src/view/main_window.py
@@ -182,7 +182,9 @@ class MainWindow(Display):
             output_file = table_widget.item(row, 1).text()
             file_type = os.path.splitext(input_file)[1].lower()
             try:
-                pydmconverter.__main__.run(input_file, output_file, file_type, override=True)
+                pydmconverter.__main__.run(
+                    input_file, output_file, file_type, override=self.options_model.override_existing
+                )
                 logger.debug(f"converted {input_file} to {output_file}")
                 table_widget.setItem(row, 2, QTableWidgetItem("Converted"))
             except Exception as msg:

--- a/app/src/view/options_window.py
+++ b/app/src/view/options_window.py
@@ -47,12 +47,20 @@ class OptionsWindow(QWidget):
         self.output_folder_select = FileSelectWidget(path=self.options_model.output_folder, select_dir=False)
         output_folder_group_layout.addWidget(self.output_folder_select)
 
+        conversion_group = QGroupBox("Conversion")
+        conversion_group_layout = QVBoxLayout()
+        conversion_group.setLayout(conversion_group_layout)
+        self.override_existing_checkbox = QCheckBox("Overwrite existing output files")
+        self.override_existing_checkbox.setChecked(self.options_model.override_existing)
+        conversion_group_layout.addWidget(self.override_existing_checkbox)
+
         self.general_group_view = QWidget()
         general_group_layout = QVBoxLayout()
         self.general_group_view.setLayout(general_group_layout)
         general_group_label = QLabel("General")
         general_group_layout.addWidget(general_group_label)
         general_group_layout.addWidget(output_folder_group)
+        general_group_layout.addWidget(conversion_group)
         general_group_layout.addStretch()
 
         edm_colors_group = QGroupBox("colors.list")
@@ -122,6 +130,7 @@ class OptionsWindow(QWidget):
         else:
             QMessageBox.critical(self, "Invalid Path", "The entered output folder path is not valid.")
             return False
+        self.options_model.override_existing = self.override_existing_checkbox.isChecked()
 
         # EDM options
         colors_path = self.edm_override_file_select.get_path()

--- a/tests/test_options_model.py
+++ b/tests/test_options_model.py
@@ -1,0 +1,38 @@
+"""Tests for the GUI options model."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "app" / "src"))
+
+from model.options_model import OptionsModel  # noqa: E402
+
+
+def test_override_existing_default():
+    model = OptionsModel()
+    assert model.override_existing is False
+
+
+def test_override_existing_round_trip(tmp_path):
+    options_file = str(tmp_path / "options.json")
+
+    model = OptionsModel()
+    model.output_folder = str(tmp_path)
+    model.override_existing = True
+    model.write_options_to_file(options_file)
+
+    loaded = OptionsModel()
+    loaded.get_options_from_file(options_file)
+    assert loaded.override_existing is True
+
+
+def test_override_existing_absent_from_file(tmp_path):
+    options_file = str(tmp_path / "options.json")
+
+    model = OptionsModel()
+    model.output_folder = str(tmp_path)
+    model.write_options_to_file(options_file)
+
+    loaded = OptionsModel()
+    loaded.get_options_from_file(options_file)
+    assert loaded.override_existing is False


### PR DESCRIPTION
## Summary

- The GUI always passed override=True, silently overwriting existing .ui files on every convert
- Adds an Overwrite existing output files checkbox to the General page of the options window, persisted in options.json alongside the other settings
- The convert button now respects the option. With it off (the default), rows whose output file already exists are marked Failed instead of being overwritten

## Testing

- Unit tests for the new option default and its round trip through options.json
- Full test suite passes, pre-commit clean

Fixes #67