### PR TITLE
FIX: translate EPICS calc operators to Python in calc expressions

### DIFF
--- a/pydmconverter/edm/parser_helpers.py
+++ b/pydmconverter/edm/parser_helpers.py
@@ -340,9 +340,16 @@ def reformat_calc_expression(exp):
     """
     Convert EPICS calc expression operators to Python equivalents.
 
-    EPICS calc uses different operators than Python:
-    - ^ for exponentiation (Python uses **)
-    - # for not equal (Python uses !=)
+    PyDM's calc plugin evaluates the ``expr`` query as a Python expression, so
+    EPICS-only operators must be translated or PyDM raises a SyntaxError when the
+    display is opened.
+
+    Conversions:
+    - ``^`` exponentiation -> ``**``
+    - ``#`` not equal -> ``!=``
+    - ``=`` equality -> ``==`` (leaving ``<=``, ``>=``, ``!=``, ``==`` untouched)
+    - ``&&`` / ``||`` -> ``and`` / ``or``
+    - ``cond ? a : b`` ternary -> ``(a if cond else b)`` (handles nesting)
     """
     # Exponentiation: ^ -> **
     exp = exp.replace("^", "**")
@@ -350,7 +357,70 @@ def reformat_calc_expression(exp):
     # Not equal: # -> !=
     exp = exp.replace("#", "!=")
 
+    # Equality: single = -> ==, without touching <=, >=, !=, ==, :=
+    exp = re.sub(r"(?<![<>=!:])=(?!=)", "==", exp)
+
+    # Logical operators
+    exp = exp.replace("&&", " and ").replace("||", " or ")
+
+    # C-style ternary -> Python conditional expression
+    exp = _convert_calc_ternary(exp)
+
     return exp
+
+
+def _convert_calc_ternary(exp: str) -> str:
+    """
+    Convert an EPICS C-style ternary ``cond ? a : b`` into the Python
+    conditional expression ``(a if cond else b)``.
+
+    Handles right-associative nesting (``a ? b : c ? d : e``) and ternaries
+    nested in the true branch (``a ? b ? c : d : e``) by balancing ``?`` and
+    ``:`` like brackets while ignoring anything inside parentheses.
+    """
+    depth = 0
+    q_index = -1
+    for i, ch in enumerate(exp):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == "?" and depth == 0:
+            q_index = i
+            break
+
+    if q_index == -1:
+        return exp
+
+    depth = 0
+    nested = 0
+    colon_index = -1
+    for i in range(q_index + 1, len(exp)):
+        ch = exp[i]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif depth == 0 and ch == "?":
+            nested += 1
+        elif depth == 0 and ch == ":":
+            if nested == 0:
+                colon_index = i
+                break
+            nested -= 1
+
+    if colon_index == -1:
+        # Unbalanced ternary; leave the expression untouched.
+        return exp
+
+    cond = exp[:q_index].strip()
+    true_part = exp[q_index + 1 : colon_index].strip()
+    false_part = exp[colon_index + 1 :].strip()
+
+    return (
+        f"({_convert_calc_ternary(true_part)} if {_convert_calc_ternary(cond)} "
+        f"else {_convert_calc_ternary(false_part)})"
+    )
 
 
 def loc_conversion(edm_string: str) -> str:

--- a/tests/edm/test_parser_helpers.py
+++ b/tests/edm/test_parser_helpers.py
@@ -10,6 +10,7 @@ from pydmconverter.edm.parser_helpers import (
     parse_calc_pv,
     apply_rewrite_rule,
     translate_calc_pv_to_pydm,
+    reformat_calc_expression,
     loc_conversion,
     replace_calc_and_loc_in_edm_content,
     parse_colors_list,
@@ -142,6 +143,39 @@ def test_translate_calc_pv_to_pydm():
     assert "A=pva://x" in pydm_inline
     assert "B=pva://y" in pydm_inline
     assert "expr=A*B" in pydm_inline
+
+
+def test_reformat_calc_expression():
+    """
+    EPICS calc operators must be translated to valid Python, since PyDM's calc
+    plugin evaluates the expression and otherwise raises a SyntaxError at open
+    time (issue #142).
+    """
+    # Already-valid Python passes through unchanged
+    assert reformat_calc_expression("A+B") == "A+B"
+
+    # Exponentiation and not-equal
+    assert reformat_calc_expression("A^2") == "A**2"
+    assert reformat_calc_expression("A#B") == "A!=B"
+
+    # Single = becomes ==, without clobbering existing comparison operators
+    assert reformat_calc_expression("A=B") == "A==B"
+    assert reformat_calc_expression("A<=B") == "A<=B"
+    assert reformat_calc_expression("A>=B") == "A>=B"
+    assert reformat_calc_expression("A!=B") == "A!=B"
+
+    # Logical operators
+    assert reformat_calc_expression("A&&B") == "A and B"
+    assert reformat_calc_expression("A||B") == "A or B"
+
+    # The exact expression from issue #142
+    assert reformat_calc_expression("A=B?1:0") == "(1 if A==B else 0)"
+
+    # Right-associative nested ternary
+    assert reformat_calc_expression("A?1:B?2:3") == "(1 if A else (2 if B else 3))"
+
+    # Ternary nested in the true branch
+    assert reformat_calc_expression("A?B?1:2:3") == "((1 if B else 2) if A else 3)"
 
 
 def test_loc_conversion():


### PR DESCRIPTION
## Summary
- Fixes #142: `mdo3xMain.edl` and `tds3xMain.edl` raised `SyntaxError: Invalid syntax. Perhaps you forgot a comma?` when opened in PyDM.
- Root cause: the converter wrote EPICS calc expressions verbatim into `calc://...&expr=...` PVs. PyDM evaluates `expr` as Python, but EPICS `=` (equality) and `cond?a:b` (ternary) are invalid Python. `reformat_calc_expression` only handled `^` and `#`.
- `reformat_calc_expression` now also converts `=`→`==` (leaving `<=`/`>=`/`!=`/`==`/`:=` intact), `&&`/`||`→`and`/`or`, and C-style ternaries into Python conditional expressions, including nested ternaries.

Example: `A=B?1:0` → `(1 if A==B else 0)`.
