### PR TITLE
Optional pydm/pyqt5 gui extra and convert_bytes (#145, #146)

### DIFF
--- a/pydmconverter/edm/converter_helpers.py
+++ b/pydmconverter/edm/converter_helpers.py
@@ -28,7 +28,12 @@ from pydmconverter.widgets import (
     PyDMWaveformTable,
     PyDMAnalogIndicator,
 )
-from pydmconverter.edm.parser_helpers import convert_color_property_to_qcolor, search_color_list, parse_colors_list
+from pydmconverter.edm.parser_helpers import (
+    convert_color_property_to_qcolor,
+    search_color_list,
+    parse_colors_list,
+    parse_edm_macros,
+)
 from pydmconverter.edm.menumux import generate_menumux_file
 from pydmconverter.exceptions import AttributeConversionError
 import logging
@@ -1315,85 +1320,6 @@ def get_string_value(value: list) -> str:
     Takes in a value string and joins each element into a string separated by a new line
     """
     return "\n".join(value)
-
-
-def _split_macro_pairs(macro_string: str) -> list[str]:
-    """Split macro string on commas, respecting ${...} nesting."""
-    pairs = []
-    current = []
-    depth = 0
-    for char in macro_string:
-        if char == "{" and depth >= 0:
-            depth += 1
-            current.append(char)
-        elif char == "}" and depth > 0:
-            depth -= 1
-            current.append(char)
-        elif char == "," and depth == 0:
-            pairs.append("".join(current))
-            current = []
-        else:
-            current.append(char)
-    if current:
-        pairs.append("".join(current))
-    return pairs
-
-
-def parse_edm_macros(macro_string: str) -> dict:
-    """
-    Parse an EDM macro string into a dictionary for PyDM widgets.
-
-    EDM macros are in the format: "KEY1=value1,KEY2=value2,KEY3=value3"
-    This function converts them to a Python dict: {"KEY1": "value1", "KEY2": "value2", "KEY3": "value3"}
-
-    Parameters
-    ----------
-    macro_string : str
-        The EDM macro string to parse (e.g., "P=CAMR:LI20:110,R=:ASYN")
-
-    Returns
-    -------
-    dict
-        A dictionary containing the parsed macro key-value pairs.
-        Returns an empty dict if the input is empty or None.
-
-    Examples
-    --------
-    >>> parse_edm_macros("P=CAMR:LI20:110,R=:ASYN")
-    {'P': 'CAMR:LI20:110', 'R': ':ASYN'}
-    >>> parse_edm_macros("DEVICE=IOC:SYS0:1")
-    {'DEVICE': 'IOC:SYS0:1'}
-    >>> parse_edm_macros("")
-    {}
-    """
-    if not macro_string or not isinstance(macro_string, str):
-        return {}
-
-    macro_dict = {}
-    macro_string = macro_string.strip()
-
-    if not macro_string:
-        return {}
-
-    pairs = _split_macro_pairs(macro_string)
-
-    for pair in pairs:
-        pair = pair.strip()
-        if not pair:
-            continue
-        if "=" in pair:
-            key, value = pair.split("=", 1)
-            key = key.strip()
-            value = value.strip()
-            if value.startswith('"') and value.endswith('"'):
-                value = value[1:-1]
-            if value.startswith("'") and value.endswith("'"):
-                value = value[1:-1]
-            macro_dict[key] = value
-        else:
-            logger.warning(f"Invalid macro pair format: '{pair}' in macro string: '{macro_string}'")
-
-    return macro_dict
 
 
 def parse_font_string(font_str: str) -> dict:

--- a/pydmconverter/edm/ir_adapter.py
+++ b/pydmconverter/edm/ir_adapter.py
@@ -15,9 +15,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from pydmconverter.edm.converter_helpers import parse_edm_macros
 from pydmconverter.edm.edm_qt import EDM_TO_QT_PROP, resolve_qt_class
 from pydmconverter.edm.parser import EDMFileParser, EDMGroup, EDMObject
+from pydmconverter.edm.parser_helpers import parse_edm_macros
 from pydmconverter.ir.builder import IRBuilder
 from pydmconverter.ir.macros import normalize_macro_syntax
 from pydmconverter.ir.model import ScreenIR

--- a/pydmconverter/edm/parser_helpers.py
+++ b/pydmconverter/edm/parser_helpers.py
@@ -1022,3 +1022,82 @@ def convert_color_property_to_qcolor(fillColor: str, color_data: Dict[str, Any])
     logger.info(f"Converted {fillColor} to color: {result}")
 
     return result
+
+
+def _split_macro_pairs(macro_string: str) -> list[str]:
+    """Split macro string on commas, respecting ${...} nesting."""
+    pairs = []
+    current = []
+    depth = 0
+    for char in macro_string:
+        if char == "{" and depth >= 0:
+            depth += 1
+            current.append(char)
+        elif char == "}" and depth > 0:
+            depth -= 1
+            current.append(char)
+        elif char == "," and depth == 0:
+            pairs.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    if current:
+        pairs.append("".join(current))
+    return pairs
+
+
+def parse_edm_macros(macro_string: str) -> dict:
+    """
+    Parse an EDM macro string into a dictionary for PyDM widgets.
+
+    EDM macros are in the format: "KEY1=value1,KEY2=value2,KEY3=value3"
+    This function converts them to a Python dict: {"KEY1": "value1", "KEY2": "value2", "KEY3": "value3"}
+
+    Parameters
+    ----------
+    macro_string : str
+        The EDM macro string to parse (e.g., "P=CAMR:LI20:110,R=:ASYN")
+
+    Returns
+    -------
+    dict
+        A dictionary containing the parsed macro key-value pairs.
+        Returns an empty dict if the input is empty or None.
+
+    Examples
+    --------
+    >>> parse_edm_macros("P=CAMR:LI20:110,R=:ASYN")
+    {'P': 'CAMR:LI20:110', 'R': ':ASYN'}
+    >>> parse_edm_macros("DEVICE=IOC:SYS0:1")
+    {'DEVICE': 'IOC:SYS0:1'}
+    >>> parse_edm_macros("")
+    {}
+    """
+    if not macro_string or not isinstance(macro_string, str):
+        return {}
+
+    macro_dict = {}
+    macro_string = macro_string.strip()
+
+    if not macro_string:
+        return {}
+
+    pairs = _split_macro_pairs(macro_string)
+
+    for pair in pairs:
+        pair = pair.strip()
+        if not pair:
+            continue
+        if "=" in pair:
+            key, value = pair.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+            if value.startswith('"') and value.endswith('"'):
+                value = value[1:-1]
+            if value.startswith("'") and value.endswith("'"):
+                value = value[1:-1]
+            macro_dict[key] = value
+        else:
+            logger.warning(f"Invalid macro pair format: '{pair}' in macro string: '{macro_string}'")
+
+    return macro_dict

--- a/pydmconverter/react.py
+++ b/pydmconverter/react.py
@@ -11,7 +11,10 @@ TSX is intentionally not produced here — that is the Screen Builder's eject pa
 from __future__ import annotations
 
 import logging
+import shutil
+import tempfile
 from pathlib import Path
+from typing import Literal
 
 from pydmconverter.edm.ir_adapter import edm_file_to_ir
 from pydmconverter.ir.emit import write_screen_json
@@ -32,6 +35,27 @@ def convert_to_ir(input_path: str | Path, *, registry: RegistryClient | None = N
     if adapter is None:
         raise ValueError(f"--target react supports {', '.join(SUPPORTED_SUFFIXES)} inputs, not {suffix!r}")
     return adapter(input_path, registry=registry)
+
+
+def convert_bytes(data: bytes, *, kind: Literal["edl", "ui"], registry: RegistryClient | None = None) -> ScreenIR:
+    """Parse raw ``.edl``/``.ui`` bytes into a Screen IR, keyed on ``kind``.
+
+    For HTTP callers (the Screen Builder uploads screens as bytes, a browser cannot
+    hand the backend a server path), so callers need not spill uploads to disk. The
+    EDM parser reads from a path, so the bytes are staged in a temp file scoped to
+    this call rather than in every caller.
+    """
+    if kind not in ("edl", "ui"):
+        raise ValueError(f"convert_bytes kind must be 'edl' or 'ui', not {kind!r}")
+    # Fixed basename in a private temp dir -> a deterministic screen id (not a random
+    # temp stem), and conversion of identical bytes is byte-stable.
+    tmp_dir = Path(tempfile.mkdtemp(prefix="pydmconv-"))
+    try:
+        staged = tmp_dir / f"screen.{kind}"
+        staged.write_bytes(data)
+        return convert_to_ir(staged, registry=registry)
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 def _screen_json_path(input_path: Path, output_path: Path) -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,6 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "pydm",
-    'pyqt5',
     "pydantic>=2",
     "jsonschema>=4",
 ]
@@ -46,11 +44,20 @@ pydmconverter = ["launch_gui.sh", "ir/data/*.json", "ir/data/widget-registry/*.j
 pydmconverter = "pydmconverter.__main__:main"
 
 [project.optional-dependencies]
+# PyQt5/PyDM are only needed for the legacy --target pydm (.ui) output, menumux,
+# and the desktop GUI. The IR / --target react path (pydmconverter.react) is pure
+# Python and imports without them.
+gui = [
+    "pydm",
+    "pyqt5",
+]
 dev = [
     "pytest",
     "pytest-cov",
     "pytest-qt",
-    "pytest-mock"
+    "pytest-mock",
+    "pydm",
+    "pyqt5",
 ]
 
 [project.urls]

--- a/tests/test_headless_import.py
+++ b/tests/test_headless_import.py
@@ -1,0 +1,35 @@
+"""The IR / react.py path must import with zero Qt/PyDM/EPICS (issue #145).
+
+The Canopy backend imports `pydmconverter.react` in a headless, slim container with
+no PyQt5/pydm/pyepics installed. This guards against a regression that re-introduces
+a module-scope Qt/EPICS import on the conversion path. It runs in a subprocess so the
+check holds even though this dev env *does* have Qt installed: the point is that the
+react path must never *touch* those modules.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_react_path_imports_without_qt_pydm_or_epics():
+    code = textwrap.dedent(
+        """
+        import sys
+        import pydmconverter.react
+        from pydmconverter.react import convert_to_ir, convert_bytes, convert_file, convert_folder
+
+        forbidden = [
+            "qtpy",
+            "pydm",
+            "epics",
+            "pydmconverter.edm.converter_helpers",
+            "pydmconverter.edm.menumux",
+            "pydmconverter.widgets",
+        ]
+        loaded = [name for name in forbidden if name in sys.modules]
+        assert not loaded, f"react path pulled in heavy modules: {loaded}"
+        """
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"

--- a/tests/test_react.py
+++ b/tests/test_react.py
@@ -14,6 +14,25 @@ def test_convert_to_ir_dispatches_by_suffix():
     assert react.convert_to_ir(UI_FIXTURE).metadata.source.type == "ui-converter"
 
 
+def test_convert_bytes_edl_and_ui():
+    """convert_bytes runs the same pipeline as convert_to_ir but is keyed on kind (#146)."""
+    edm = react.convert_bytes(EDM_FIXTURE.read_bytes(), kind="edl")
+    ui = react.convert_bytes(UI_FIXTURE.read_bytes(), kind="ui")
+    assert edm.metadata.source.type == "edl-converter"
+    assert ui.metadata.source.type == "ui-converter"
+    assert edm.root.children  # produced widgets through the shared builder
+
+
+def test_convert_bytes_is_deterministic():
+    data = EDM_FIXTURE.read_bytes()
+    assert react.convert_bytes(data, kind="edl") == react.convert_bytes(data, kind="edl")
+
+
+def test_convert_bytes_rejects_bad_kind():
+    with pytest.raises(ValueError, match="kind"):
+        react.convert_bytes(b"<x/>", kind="txt")
+
+
 def test_convert_to_ir_rejects_unknown_suffix(tmp_path):
     bogus = tmp_path / "x.txt"
     bogus.write_text("nope", encoding="utf-8")


### PR DESCRIPTION
Stacked on `yektay/react-rework` (base of this PR). The diff is just these two changes; review after #147 or with that base selected.

## #145 - make pydm/pyqt5 optional so the IR / react path imports without Qt

The IR / `react.py` path transitively pulled Qt and EPICS at import time through `converter_helpers` (`-> menumux -> qtpy/pydm`, and `-> widgets -> epics`). This:

- Relocates `parse_edm_macros` (+ `_split_macro_pairs`) to the pure `parser_helpers` module and re-points `ir_adapter` at it, so the IR path no longer imports `converter_helpers` at all. That removes both the menumux/Qt and the widgets/epics contamination in one move. `converter_helpers` re-exports `parse_edm_macros` for back-compat.
- Moves `pydm` and `pyqt5` out of core `dependencies` into a `gui` optional extra. Core install is now `pydantic` + `jsonschema` (pure Python). `pip install PyDMConverter[gui]` restores the legacy `.ui` output, menumux, and the desktop GUI.

`tests/test_headless_import.py` runs a subprocess asserting that `import pydmconverter.react` loads none of `qtpy`, `pydm`, `epics`, `converter_helpers`, `menumux`, or `widgets`, guarding against regressions.

## #146 - add convert_bytes(data, kind)

Adds a bytes-based entry point next to the path-based ones, for the Canopy backend's multipart uploads (a browser cannot hand the server a filesystem path). It stages the bytes in a private temp dir under a fixed `screen.<kind>` name (so the screen id is deterministic) and delegates to the same `convert_to_ir` pipeline. `convert_to_ir(path)` is unchanged.

Closes #145
Closes #146

247 tests pass, pre-commit clean.
