### PR TITLE
Conform converter to canonical @canopy/screen-ir schema

### DIFF
--- a/pydmconverter/ir/data/VENDORED_SCHEMA.md
+++ b/pydmconverter/ir/data/VENDORED_SCHEMA.md
@@ -1,0 +1,25 @@
+# Vendored `@canopy/screen-ir` schema
+
+`screen-ir.schema.json` in this directory is **vendored**, not generated here.
+`@canopy/screen-ir` owns the Canopy screen contract; this converter is a
+disposable consumer that must produce IR the editor accepts. The converter
+validates its output against this file (`validate_screen_json`); it does not
+mint the contract.
+
+## Pinned source
+
+- Package: `@canopy/screen-ir`
+- Version: `0.2.0` (`package.json` at the pinned commit)
+- Repo: `canopy-screen-builder`, branch `main` (PR #2 merged)
+- Commit: `affddbc` ("Add @canopy/screen-ir: the canonical, read-tolerant
+  screen IR" — step 1; on `main` via merge `a706d4a`)
+- Source path in that repo: `packages/screen-ir/schema/screen-ir.schema.json`
+
+## Re-vendoring
+
+Because this tool is short-lived there is no live sync. To refresh, copy the
+file from the pinned source path above and update the commit/version here, then
+run `python -m pytest tests/ir/test_ir_schema.py` to confirm converter output
+still validates. If validation fails, reconcile per
+`plans/converter-conformance-handoff.md`: fix converter output, or file a change
+against `@canopy/screen-ir` — do NOT widen only the converter's copy.

--- a/pydmconverter/ir/data/screen-ir.schema.json
+++ b/pydmconverter/ir/data/screen-ir.schema.json
@@ -1,424 +1,163 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://controls.slac.stanford.edu/schemas/screen-ir/1.0/schema.json",
+  "title": "Canopy Screen IR",
+  "description": "Canonical Canopy screen Intermediate Representation. Owned by @canopy/screen-ir; mirrors the TypeScript types in src/. This file is the structural subset of the contract; cross-field rules (macro defaults, the Rule union arm, fox:// resolution) are enforced by validate()'s semantic layer.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "id", "metadata", "macros", "root"],
+  "properties": {
+    "schemaVersion": { "const": "1.0" },
+    "kind": { "enum": ["screen", "template"] },
+    "id": { "type": "string" },
+    "metadata": { "$ref": "#/$defs/ScreenMetadata" },
+    "macros": { "type": "array", "items": { "$ref": "#/$defs/MacroDeclaration" } },
+    "formulas": { "type": "array", "items": { "$ref": "#/$defs/FormulaDeclaration" } },
+    "root": { "$ref": "#/$defs/WidgetNode" }
+  },
   "$defs": {
-    "FormulaDeclaration": {
-      "description": "A screen-level Fox formula (converter handoff 6.3).\n\nShape-compatible with ``canopy.contracts.formula.FormulaSpec`` plus a\n``name``. ``calc://`` expressions are hoisted here (deduped) and referenced\nfrom a widget channel prop as ``fox://<name>``.",
+    "ScreenMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "source", "size"],
       "properties": {
-        "bindings": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "title": "Bindings",
-          "type": "object"
-        },
-        "expression": {
-          "title": "Expression",
-          "type": "string"
-        },
-        "kind": {
-          "default": "scalar",
-          "enum": [
-            "scalar",
-            "timeseries",
-            "waveform"
-          ],
-          "title": "Kind",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "type": "string"
-        }
-      },
-      "required": [
-        "name",
-        "expression"
-      ],
-      "title": "FormulaDeclaration",
-      "type": "object"
+        "title": { "type": "string" },
+        "source": { "$ref": "#/$defs/ScreenSource" },
+        "size": { "$ref": "#/$defs/ScreenSize" },
+        "description": { "type": "string" },
+        "author": { "type": "string" }
+      }
     },
-    "Geometry": {
-      "description": "Absolute-only geometry (D4). Origin is the parent's top-left.",
+    "ScreenSize": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["width", "height"],
       "properties": {
-        "height": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "number"
-            }
-          ],
-          "title": "Height"
-        },
-        "width": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "number"
-            }
-          ],
-          "title": "Width"
-        },
-        "x": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "number"
-            }
-          ],
-          "title": "X"
-        },
-        "y": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "number"
-            }
-          ],
-          "title": "Y"
-        }
-      },
-      "required": [
-        "x",
-        "y",
-        "width",
-        "height"
-      ],
-      "title": "Geometry",
-      "type": "object"
+        "width": { "type": "number" },
+        "height": { "type": "number" }
+      }
+    },
+    "ScreenSource": {
+      "description": "Open by design: `type` is any string so the editor reads converter-stamped source types (e.g. 'edl-converter') forever. The named variants are documentation, not an exhaustive list.",
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string" },
+        "savedAt": { "type": "string" },
+        "sourceFile": { "type": "string" },
+        "convertedAt": { "type": "string" }
+      }
     },
     "MacroDeclaration": {
-      "description": "A screen-level macro (D6 / macros design M2).\n\n``default`` is required for ``kind: \"screen\"`` and forbidden for\n``kind: \"template\"`` — enforced on :class:`ScreenIR`.",
+      "description": "default required on a screen, forbidden on a template — enforced in validate(), not expressible here.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name"],
       "properties": {
-        "default": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Default"
-        },
-        "description": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Description"
-        },
-        "name": {
-          "pattern": "^[A-Z][A-Z0-9_]*$",
-          "title": "Name",
-          "type": "string"
-        }
-      },
-      "required": [
-        "name"
-      ],
-      "title": "MacroDeclaration",
-      "type": "object"
+        "name": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$" },
+        "default": { "type": "string" },
+        "description": { "type": "string" }
+      }
     },
-    "Metadata": {
+    "FormulaDeclaration": {
+      "description": "Screen-level Fox formula, referenced by name via fox://<name>.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "expression"],
       "properties": {
-        "size": {
-          "$ref": "#/$defs/Size"
-        },
-        "source": {
-          "$ref": "#/$defs/Source"
-        },
-        "title": {
-          "title": "Title",
-          "type": "string"
+        "name": { "type": "string" },
+        "kind": { "enum": ["scalar", "timeseries", "waveform"] },
+        "expression": { "type": "string" },
+        "bindings": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
         }
-      },
-      "required": [
-        "title",
-        "source",
-        "size"
-      ],
-      "title": "Metadata",
-      "type": "object"
+      }
     },
-    "NodeMeta": {
-      "description": "Editor annotations preserved on round-trip, ignored by the runtime (D17).",
+    "Geometry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["x", "y", "width", "height"],
       "properties": {
-        "comment": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Comment"
-        }
-      },
-      "title": "NodeMeta",
-      "type": "object"
+        "x": { "type": "number" },
+        "y": { "type": "number" },
+        "width": { "type": "number" },
+        "height": { "type": "number" }
+      }
     },
-    "Rule": {
-      "description": "A property rule in author form (D7/D15, REVISED 2026-06-16).\n\nThe runtime ``FormulaSpec`` is derived client-side at subscribe time and is\nnever stored here. Any bindable (scalar/enum, non ``pv-channel``) property\nmay be targeted.",
+    "WidgetMeta": {
+      "type": "object",
+      "additionalProperties": false,
       "properties": {
-        "conditions": {
-          "items": {
-            "$ref": "#/$defs/RuleCondition"
-          },
-          "title": "Conditions",
-          "type": "array"
-        },
-        "default": {
-          "default": null,
-          "title": "Default"
-        },
-        "id": {
-          "title": "Id",
-          "type": "string"
-        },
-        "name": {
-          "title": "Name",
-          "type": "string"
-        },
-        "pvs": {
-          "items": {
-            "$ref": "#/$defs/RulePV"
-          },
-          "title": "Pvs",
-          "type": "array"
-        },
-        "targetProperty": {
-          "title": "Targetproperty",
-          "type": "string"
-        }
-      },
-      "required": [
-        "id",
-        "name",
-        "targetProperty"
-      ],
-      "title": "Rule",
-      "type": "object"
-    },
-    "RuleCondition": {
-      "description": "One ordered condition -> value pair.\n\n``expression`` references the rule's PVs by 0-based index (``{0}``, ``{1}``)\nso it stays stable across PV renames. ``value`` is the value written to the\ntarget property when the condition holds.",
-      "properties": {
-        "expression": {
-          "title": "Expression",
-          "type": "string"
-        },
-        "value": {
-          "title": "Value"
-        }
-      },
-      "required": [
-        "expression",
-        "value"
-      ],
-      "title": "RuleCondition",
-      "type": "object"
-    },
-    "RulePV": {
-      "description": "A PV referenced by a rule. ``trigger`` marks it as a re-eval input.",
-      "properties": {
-        "name": {
-          "title": "Name",
-          "type": "string"
-        },
-        "trigger": {
-          "default": true,
-          "title": "Trigger",
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "name"
-      ],
-      "title": "RulePV",
-      "type": "object"
-    },
-    "Size": {
-      "properties": {
-        "height": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "number"
-            }
-          ],
-          "title": "Height"
-        },
-        "width": {
-          "anyOf": [
-            {
-              "type": "integer"
-            },
-            {
-              "type": "number"
-            }
-          ],
-          "title": "Width"
-        }
-      },
-      "required": [
-        "width",
-        "height"
-      ],
-      "title": "Size",
-      "type": "object"
-    },
-    "Source": {
-      "description": "Provenance of the screen. ``type`` is e.g. ``\"edl-converter\"``.",
-      "properties": {
-        "savedAt": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Savedat"
-        },
-        "type": {
-          "title": "Type",
-          "type": "string"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "title": "Source",
-      "type": "object"
+        "comment": { "type": "string" }
+      }
     },
     "WidgetNode": {
-      "description": "A single widget in the tree (D1, D2, D3, D7, D11, D14, D17).",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "props", "geometry"],
       "properties": {
-        "children": {
-          "items": {
-            "$ref": "#/$defs/WidgetNode"
-          },
-          "title": "Children",
-          "type": "array"
-        },
-        "geometry": {
-          "$ref": "#/$defs/Geometry"
-        },
-        "id": {
-          "title": "Id",
-          "type": "string"
-        },
-        "meta": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NodeMeta"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null
-        },
+        "id": { "type": "string" },
+        "type": { "type": "string" },
         "props": {
-          "additionalProperties": true,
-          "title": "Props",
+          "description": "Untagged JSON literals. Open by design: per-widget prop sets are not enumerated here. fox:// references live in designated channel props; resolution is checked in validate().",
           "type": "object"
         },
-        "rules": {
-          "items": {
-            "$ref": "#/$defs/Rule"
-          },
-          "title": "Rules",
-          "type": "array"
+        "geometry": { "$ref": "#/$defs/Geometry" },
+        "children": { "type": "array", "items": { "$ref": "#/$defs/WidgetNode" } },
+        "rules": { "type": "array", "items": { "$ref": "#/$defs/Rule" } },
+        "meta": { "$ref": "#/$defs/WidgetMeta" },
+        "warnings": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "RulePvBinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "trigger"],
+      "properties": {
+        "name": { "type": "string" },
+        "trigger": { "type": "boolean" }
+      }
+    },
+    "RuleCondition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["expression", "value"],
+      "properties": {
+        "expression": { "type": "string" },
+        "value": { "type": ["string", "number", "boolean", "null"] }
+      }
+    },
+    "RuleScalar": { "type": ["string", "number", "boolean", "null"] },
+    "Rule": {
+      "description": "Discriminated union: conditional arm (pvs + conditions, what the converter emits) or formula arm (formula). validate() enforces exactly one arm.",
+      "type": "object",
+      "required": ["id", "name", "targetProperty", "default"],
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["id", "name", "targetProperty", "default", "pvs", "conditions"],
+          "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" },
+            "targetProperty": { "type": "string" },
+            "default": { "$ref": "#/$defs/RuleScalar" },
+            "pvs": { "type": "array", "items": { "$ref": "#/$defs/RulePvBinding" } },
+            "conditions": { "type": "array", "items": { "$ref": "#/$defs/RuleCondition" } }
+          }
         },
-        "type": {
-          "title": "Type",
-          "type": "string"
-        },
-        "warnings": {
-          "items": {
-            "type": "string"
-          },
-          "title": "Warnings",
-          "type": "array"
+        {
+          "additionalProperties": false,
+          "required": ["id", "name", "targetProperty", "default", "formula"],
+          "properties": {
+            "id": { "type": "string" },
+            "name": { "type": "string" },
+            "targetProperty": { "type": "string" },
+            "default": { "$ref": "#/$defs/RuleScalar" },
+            "formula": { "type": "string" }
+          }
         }
-      },
-      "required": [
-        "id",
-        "type",
-        "geometry"
-      ],
-      "title": "WidgetNode",
-      "type": "object"
+      ]
     }
-  },
-  "$id": "https://canopy.slac.stanford.edu/schemas/screen-ir/1.0/schema.json",
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "description": "The canonical screen representation — the converter's single output seam.",
-  "properties": {
-    "formulas": {
-      "items": {
-        "$ref": "#/$defs/FormulaDeclaration"
-      },
-      "title": "Formulas",
-      "type": "array"
-    },
-    "id": {
-      "title": "Id",
-      "type": "string"
-    },
-    "kind": {
-      "default": "screen",
-      "enum": [
-        "screen",
-        "template"
-      ],
-      "title": "Kind",
-      "type": "string"
-    },
-    "macros": {
-      "items": {
-        "$ref": "#/$defs/MacroDeclaration"
-      },
-      "title": "Macros",
-      "type": "array"
-    },
-    "metadata": {
-      "$ref": "#/$defs/Metadata"
-    },
-    "root": {
-      "$ref": "#/$defs/WidgetNode"
-    },
-    "schemaVersion": {
-      "const": "1.0",
-      "default": "1.0",
-      "title": "Schemaversion",
-      "type": "string"
-    }
-  },
-  "required": [
-    "id",
-    "metadata",
-    "root"
-  ],
-  "title": "Canopy Screen IR",
-  "type": "object"
+  }
 }

--- a/pydmconverter/ir/schema.py
+++ b/pydmconverter/ir/schema.py
@@ -1,13 +1,15 @@
-"""IR JSON Schema generation and validation.
+"""IR JSON Schema validation against the vendored ``@canopy/screen-ir`` contract.
 
-The Pydantic models are the source of truth. ``build_schema()`` derives a JSON
-Schema from them; that schema is committed at :data:`SCHEMA_PATH` as the contract
-artifact for ``@canopy/screen-ir`` and the Screen Builder's ajv validator. A test
-regenerates and compares so the committed file can never drift from the models.
+Ownership note: ``@canopy/screen-ir`` owns the Canopy screen contract. This
+converter is disposable migration scaffolding — a *consumer* that must produce
+IR the editor accepts; it does not get to define the format. So the schema this
+module validates against is **vendored** from ``@canopy/screen-ir`` (see
+``data/VENDORED_SCHEMA.md`` for the pinned version/commit), not minted here.
 
-``validate_screen_json`` validates a wire dict against the schema (belt-and-braces
-on top of Pydantic's own validation), so the converter can guarantee every emitted
-``*.screen.json`` conforms before it is written.
+The Pydantic models in :mod:`pydmconverter.ir.model` remain the way the converter
+*builds* IR internally. ``validate_screen_json`` checks an emitted wire dict
+against the vendored editor schema, so the converter can guarantee every
+``*.screen.json`` it writes conforms to the real Canopy contract before it lands.
 """
 
 from __future__ import annotations
@@ -18,45 +20,19 @@ from typing import Any
 
 from jsonschema import Draft202012Validator
 
-from pydmconverter.ir.model import ScreenIR
-
 DATA_DIR = Path(__file__).parent / "data"
+
+#: The vendored ``@canopy/screen-ir`` schema. This is the contract the converter
+#: validates against. Owned upstream; see ``data/VENDORED_SCHEMA.md`` for the pin.
 SCHEMA_PATH = DATA_DIR / "screen-ir.schema.json"
-
-SCHEMA_ID = "https://canopy.slac.stanford.edu/schemas/screen-ir/1.0/schema.json"
-
-
-def build_schema() -> dict[str, Any]:
-    """Generate the IR JSON Schema from the Pydantic models (camelCase keys)."""
-    schema = ScreenIR.model_json_schema(by_alias=True)
-    # Stamp identity onto the generated schema. Pydantic emits a 2020-12 schema.
-    schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
-    schema["$id"] = SCHEMA_ID
-    schema["title"] = "Canopy Screen IR"
-    return schema
-
-
-def schema_json(*, indent: int = 2) -> str:
-    """The generated schema as a deterministic JSON string with trailing newline."""
-    return json.dumps(build_schema(), indent=indent, ensure_ascii=False, sort_keys=True) + "\n"
-
-
-def write_schema(path: str | Path = SCHEMA_PATH) -> Path:
-    """Write the generated schema to ``path`` (defaults to the committed location)."""
-    out = Path(path)
-    out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(schema_json(), encoding="utf-8")
-    return out
 
 
 def load_schema() -> dict[str, Any]:
-    """Load the committed schema, falling back to a freshly generated one."""
-    if SCHEMA_PATH.is_file():
-        return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
-    return build_schema()
+    """Load the vendored ``@canopy/screen-ir`` schema (the validation contract)."""
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
 
 
 def validate_screen_json(data: dict[str, Any], schema: dict[str, Any] | None = None) -> list[str]:
-    """Validate a wire dict against the IR schema. Returns a list of error messages."""
+    """Validate a wire dict against the vendored IR schema. Returns error messages."""
     validator = Draft202012Validator(schema or load_schema())
     return [f"{'/'.join(map(str, err.path))}: {err.message}" for err in validator.iter_errors(data)]

--- a/tests/ir/test_ir_schema.py
+++ b/tests/ir/test_ir_schema.py
@@ -1,21 +1,42 @@
 from pydmconverter.ir.emit import to_wire_dict
-from pydmconverter.ir.schema import SCHEMA_PATH, schema_json, validate_screen_json
+from pydmconverter.ir.schema import SCHEMA_PATH, load_schema, validate_screen_json
 
 
-def test_committed_schema_not_drifted():
-    """The committed screen-ir.schema.json must match what the models generate.
+def test_vendored_schema_is_the_canonical_contract():
+    """The schema we validate against is the *vendored* @canopy/screen-ir contract.
 
-    If this fails, regenerate it: `python -m pydmconverter.ir.schema` style call,
-    or `from pydmconverter.ir.schema import write_schema; write_schema()`.
+    @canopy/screen-ir owns the contract; this converter is a consumer. The vendored
+    file is the editor's canonical schema (discriminated Rule union, open
+    ScreenSource, sealed objects), NOT a schema this repo generates from its own
+    models. These markers catch an accidental revert to a self-minted schema.
     """
-    assert SCHEMA_PATH.is_file(), f"missing committed schema at {SCHEMA_PATH}"
-    committed = SCHEMA_PATH.read_text(encoding="utf-8")
-    assert committed == schema_json(), "committed IR schema is stale — regenerate with write_schema()"
+    assert SCHEMA_PATH.is_file(), f"missing vendored schema at {SCHEMA_PATH}"
+    schema = load_schema()
+    # Owned-upstream provenance and structural markers unique to the canonical file.
+    assert "Owned by @canopy/screen-ir" in schema["description"]
+    rule = schema["$defs"]["Rule"]
+    assert "oneOf" in rule, "vendored Rule must be the discriminated union (conditional | formula arm)"
+    # The vendored schema seals top-level objects; the model-generated one does not.
+    assert schema.get("additionalProperties") is False
 
 
-def test_emitted_ir_validates(sample_screen):
-    """A representative emitted screen validates against the IR schema."""
+def test_emitted_ir_validates_against_vendored_schema(sample_screen):
+    """A representative emitted screen conforms to the vendored editor contract."""
     assert validate_screen_json(to_wire_dict(sample_screen)) == []
+
+
+def test_converter_only_emits_the_conditional_rule_arm(sample_screen):
+    """The converter emits the conditional arm (pvs + conditions), never the formula arm."""
+    wire = to_wire_dict(sample_screen)
+
+    def walk(node):
+        for rule in node.get("rules", []):
+            assert "conditions" in rule and "pvs" in rule
+            assert "formula" not in rule, "converter must not emit the editor-authored formula arm"
+        for child in node.get("children", []):
+            walk(child)
+
+    walk(wire["root"])
 
 
 def test_invalid_ir_is_rejected():
@@ -23,3 +44,39 @@ def test_invalid_ir_is_rejected():
     bad = {"schemaVersion": "1.0", "kind": "screen", "id": "s"}  # no metadata, no root
     errors = validate_screen_json(bad)
     assert errors, "expected schema validation errors for an incomplete screen"
+
+
+def test_no_dangling_fox_references(sample_screen):
+    """Every fox://X referenced in props resolves to a formulas[] entry named X.
+
+    The editor's validate() rejects dangling refs; the converter never produces one
+    (each fox:// is minted alongside its formula). This guards that invariant.
+    """
+    wire = to_wire_dict(sample_screen)
+    declared = {f["name"] for f in wire.get("formulas", [])}
+
+    def fox_name(value):
+        """The name in a ``fox://<name>`` string, or None if it isn't one."""
+        prefix = "fox://"
+        if isinstance(value, str) and value.startswith(prefix):
+            return value[len(prefix) :]
+        return None
+
+    def referenced(node):
+        for value in node.get("props", {}).values():
+            if (name := fox_name(value)) is not None:
+                yield name
+        for rule in node.get("rules", []):
+            for pv in rule.get("pvs", []):
+                if (name := fox_name(pv.get("name"))) is not None:
+                    yield name
+        for child in node.get("children", []):
+            yield from referenced(child)
+
+    dangling = [name for name in referenced(wire["root"]) if name not in declared]
+    assert dangling == [], f"dangling fox:// references: {dangling}"
+
+
+def test_vendored_schema_is_valid_json():
+    """Sanity: the vendored file parses as JSON (a copy/paste corruption tripwire)."""
+    load_schema()


### PR DESCRIPTION
## Description 
conform the EDM/UI→PyDM converter to the canonical `@canopy/screen-ir` schema. Implements the **ownership flip** now `@canopy/screen-ir` owns the screen contract; this converter is a disposable consumer that must produce IR the editor accepts, rather than minting its own contract.

## Changes

- **Vendor the canonical schema.** `pydmconverter/ir/data/screen-ir.schema.json` is now a vendored copy of `@canopy/screen-ir`'s schema (the discriminated `Rule` `oneOf`, sealed `additionalProperties: false`, open `ScreenSource`), not self-generated.
- **`ir/schema.py` is a consumer, not the source of truth.** `validate_screen_json`/`load_schema` validate against the vendored file. Dropped the "contract for @canopy/screen-ir" framing and `write_schema()`; demoted `build_schema()` to a non-authoritative internal debug aid. Pydantic models in `ir/model.py` stay — they're how the converter *builds* IR internally.
- **`ir/data/VENDORED_SCHEMA.md`** records the pin and re-vendoring procedure (no live sync — short-lived tool).
- **Tests** (`tests/ir/test_ir_schema.py`): replaced the old committed-vs-generated drift test with conformance tests — the vendored file is canonical, emitted IR validates against it, only the conditional rule arm is emitted, and there are no dangling `fox://` references.

## Pin

Pinned to `@canopy/screen-ir` **v0.2.0**, commit `f23effb` on `canopy-screen-builder` branch `add-screen-ir-package` (pushed to origin and stable). Schema content is byte-identical to that commit (verified by SHA).

## Verification

- Converter suite: **255 passed, 1 skipped** (the known group-parsing skip).
- Schema conformance tests: **6 passed**.
- Canopy `canopy.converter` (PR #41) golden `.edl -> .screen.json` snapshot: **passed**; **golden fixture unchanged** (byte-identical), so the editor branch does not need to re-vendor it.
- Editor's `@canopy/screen-ir` `validate()` conformance suite: **6 passed** against the converter's golden screen.
