### PR TITLE
FIX: grant GITHUB_TOKEN write permission for gh-pages deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     if: ${{ github.repository == 'slaclab/pydm-converter-tool' }}


### PR DESCRIPTION
## Problem

The **Publish Documentation** workflow fails on `main` pushes with:

```
remote: Permission to slaclab/pydm-converter-tool.git denied to github-actions[bot].
fatal: unable to access '...': The requested URL returned error: 403
```

The `peaceiris/actions-gh-pages` step pushes the built docs to the `gh-pages` branch using the default `GITHUB_TOKEN`. Since GitHub defaults the token to **read-only**, the push is rejected.

## Fix

Add a workflow-level `permissions: contents: write` block so `GITHUB_TOKEN` can push to `gh-pages`.

## Note

If the `slaclab` org enforces read-only workflow tokens org-wide (Settings → Actions → General → Workflow permissions), this block alone won't be enough and an admin would need to relax that policy or the workflow would need a PAT/deploy key. This change resolves the common case first.