### PR TITLE
ADD: registry support for QWidget, PyDMWaveformPlot, PyDMShellCommand

### DIFF
--- a/pydmconverter/ir/data/widget-registry/qwidget-container.json
+++ b/pydmconverter/ir/data/widget-registry/qwidget-container.json
@@ -1,0 +1,44 @@
+{
+  "id": "qwidget-container",
+  "version": "1.0.0",
+  "displayName": "Container",
+  "description": "A plain Qt QWidget used as a container/panel. Holds absolute-positioned children with no visible chrome. Maps from a non-root QWidget in a .ui file (the root form is consumed as the screen, not a child).",
+  "category": "containers",
+  "paletteIcon": "group.svg",
+
+  "reactComponent": {
+    "name": "Group",
+    "module": "@canopy/widgets"
+  },
+
+  "qtMapping": {
+    "class": "QWidget",
+    "extends": "QWidget"
+  },
+
+  "propSchema": {
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+      "layoutMode": {
+        "type": "string",
+        "enum": ["absolute", "flex", "grid"],
+        "default": "absolute"
+      }
+    }
+  },
+
+  "qtPropMap": {},
+
+  "inspectorSchema": {
+    "groups": [
+      { "name": "Display", "fields": ["layoutMode"] }
+    ]
+  },
+
+  "defaults": { "width": 200, "height": 150 },
+
+  "supportsPv": false,
+  "supportsRules": true,
+  "supportsChildren": true
+}

--- a/pydmconverter/ir/data/widget-registry/shell-command-button.json
+++ b/pydmconverter/ir/data/widget-registry/shell-command-button.json
@@ -1,0 +1,59 @@
+{
+  "id": "shell-command-button",
+  "version": "1.0.0",
+  "displayName": "Shell Command Button",
+  "description": "A button that runs one or more shell commands when clicked.",
+  "category": "controls",
+  "paletteIcon": "shell-command-button.svg",
+
+  "reactComponent": {
+    "name": "PVShellCommand",
+    "module": "@canopy/widgets"
+  },
+
+  "qtMapping": {
+    "class": "PyDMShellCommand",
+    "extends": "PyDMPushButton",
+    "header": "pydm.widgets.shell_command"
+  },
+
+  "propSchema": {
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+      "command": {
+        "type": "string",
+        "description": "Shell command to execute on click (first of the widget's commands list)."
+      },
+      "label": { "type": "string" },
+      "showIcon": { "type": "boolean", "default": false },
+      "allowMultipleExecutions": { "type": "boolean", "default": false },
+      "alarmSensitive": { "type": "boolean", "default": false },
+      "alarmBorder": { "type": "boolean", "default": false }
+    }
+  },
+
+  "qtPropMap": {
+    "commands": { "to": "command", "transform": "firstOf" },
+    "command": { "to": "command" },
+    "text": { "to": "label" },
+    "showIcon": { "to": "showIcon" },
+    "allowMultipleExecutions": { "to": "allowMultipleExecutions" },
+    "alarmSensitiveContent": { "to": "alarmSensitive" },
+    "alarmSensitiveBorder": { "to": "alarmBorder" }
+  },
+
+  "inspectorSchema": {
+    "groups": [
+      { "name": "Command", "fields": ["command", "allowMultipleExecutions"] },
+      { "name": "Display", "fields": ["label", "showIcon"] },
+      { "name": "Alarm", "fields": ["alarmSensitive", "alarmBorder"] }
+    ]
+  },
+
+  "defaults": { "width": 120, "height": 32 },
+
+  "supportsPv": false,
+  "supportsRules": true,
+  "supportsChildren": false
+}

--- a/pydmconverter/ir/data/widget-registry/waveform-plot.json
+++ b/pydmconverter/ir/data/widget-registry/waveform-plot.json
@@ -1,0 +1,62 @@
+{
+  "id": "waveform-plot",
+  "version": "1.0.0",
+  "displayName": "Waveform Plot",
+  "description": "An XY / waveform plot of one or more PV curves.",
+  "category": "charts",
+  "paletteIcon": "waveform-plot.svg",
+
+  "reactComponent": {
+    "name": "PVWaveformPlot",
+    "module": "@canopy/widgets"
+  },
+
+  "qtMapping": {
+    "class": "PyDMWaveformPlot",
+    "extends": "PyDMWaveformPlot",
+    "header": "pydm.widgets.waveformplot"
+  },
+
+  "propSchema": {
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+      "title": { "type": "string" },
+      "curves": {
+        "type": "array",
+        "items": { "type": "object" },
+        "description": "Per-curve config (y_channel, x_channel, color, lineStyle, ...)."
+      },
+      "yAxes": {
+        "type": "array",
+        "items": { "type": "object" },
+        "description": "Per-axis config (name, orientation, label, min/max range, ...)."
+      },
+      "xLabels": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    }
+  },
+
+  "qtPropMap": {
+    "title": { "to": "title" },
+    "curves": { "to": "curves", "transform": "parseJsonStrings" },
+    "yAxes": { "to": "yAxes", "transform": "parseJsonStrings" },
+    "xLabels": { "to": "xLabels" }
+  },
+
+  "inspectorSchema": {
+    "groups": [
+      { "name": "Display", "fields": ["title"] },
+      { "name": "Curves", "fields": ["curves"] },
+      { "name": "Axes", "fields": ["yAxes", "xLabels"] }
+    ]
+  },
+
+  "defaults": { "width": 400, "height": 300 },
+
+  "supportsPv": false,
+  "supportsRules": true,
+  "supportsChildren": false
+}

--- a/pydmconverter/ir/transforms.py
+++ b/pydmconverter/ir/transforms.py
@@ -14,6 +14,7 @@ skips any mapped prop whose transformed value is ``DROP``.
 
 from __future__ import annotations
 
+import json
 import re
 from typing import Any, Callable
 
@@ -143,6 +144,32 @@ def edm_line_style(value: Any) -> Any:
     return "solid"
 
 
+def parse_json_strings(value: Any) -> Any:
+    """A ``stringlist`` of JSON blobs -> a list of parsed objects.
+
+    PyDM's ``PyDMWaveformPlot`` stores ``curves`` / ``yAxes`` as a Qt stringlist
+    where each entry is a JSON document (one per curve / axis). The ``.ui`` adapter
+    hands those through as a ``list[str]``; this parses each element. Tolerant:
+    an unparseable entry is skipped rather than raising, so one malformed curve
+    does not sink the whole plot. A lone JSON string (not a list) is wrapped.
+    Non-string / already-parsed values pass through unchanged.
+    """
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, (list, tuple)):
+        return value
+    parsed: list[Any] = []
+    for item in value:
+        if not isinstance(item, str):
+            parsed.append(item)
+            continue
+        try:
+            parsed.append(json.loads(item))
+        except (ValueError, TypeError):
+            continue
+    return parsed
+
+
 TRANSFORMS: dict[str, Callable[[Any], Any]] = {
     "stripProtocol": strip_protocol,
     "boolToFromPV": bool_to_from_pv,
@@ -153,6 +180,7 @@ TRANSFORMS: dict[str, Callable[[Any], Any]] = {
     "qtScrollPolicy": qt_scroll_policy,
     "firstOf": first_of,
     "edmLineStyle": edm_line_style,
+    "parseJsonStrings": parse_json_strings,
 }
 
 

--- a/tests/ir/test_ir_registry.py
+++ b/tests/ir/test_ir_registry.py
@@ -108,3 +108,32 @@ def test_widget_definition_ignores_unknown_fields():
 def test_gateway_registry_is_a_registry_client_but_unimplemented():
     """The Canopy-port backend satisfies the protocol shape but is not wired here."""
     assert isinstance(BeaverGatewayRegistry(), RegistryClient)
+
+
+def test_newly_supported_ui_classes_resolve_by_qt_class():
+    """QWidget / PyDMShellCommand / PyDMWaveformPlot resolve instead of unknown-widget."""
+    reg = VendoredRegistry()
+    expected = {
+        "QWidget": "qwidget-container",
+        "PyDMShellCommand": "shell-command-button",
+        "PyDMWaveformPlot": "waveform-plot",
+    }
+    for qt_class, widget_id in expected.items():
+        definition = reg.by_qt_class(qt_class)
+        assert definition is not None, f"no definition for qt_class {qt_class!r}"
+        assert definition.id == widget_id
+
+
+def test_qwidget_container_supports_children():
+    """A non-root QWidget maps to a container that holds children with absolute geometry."""
+    reg = VendoredRegistry()
+    container = reg.by_qt_class("QWidget")
+    assert container is not None
+    assert container.supports_children is True
+
+
+def test_group_stays_sb_native():
+    """group must remain SB-native (no Qt class) — QWidget uses qwidget-container instead."""
+    reg = VendoredRegistry()
+    assert reg.by_id("group").qt_class is None
+    assert reg.by_qt_class("QWidget").id != "group"

--- a/tests/ir/test_ir_transforms.py
+++ b/tests/ir/test_ir_transforms.py
@@ -73,6 +73,18 @@ def test_edm_line_style():
     assert apply_transform("edmLineStyle", "anything") == "solid"
 
 
+def test_parse_json_strings():
+    # a stringlist of JSON blobs -> list of parsed objects
+    assert apply_transform("parseJsonStrings", ['{"a": 1}', '{"b": 2}']) == [{"a": 1}, {"b": 2}]
+    # a malformed entry is skipped, not fatal
+    assert apply_transform("parseJsonStrings", ['{"a": 1}', "not json"]) == [{"a": 1}]
+    # a lone JSON string is wrapped into a one-element list
+    assert apply_transform("parseJsonStrings", '{"a": 1}') == [{"a": 1}]
+    # empty list stays empty; non-list passes through
+    assert apply_transform("parseJsonStrings", []) == []
+    assert apply_transform("parseJsonStrings", 5) == 5
+
+
 def test_unknown_transform_raises():
     with pytest.raises(KeyError):
         apply_transform("notARealTransform", "x")

--- a/tests/ui/fixtures/newly_supported.ui
+++ b/tests/ui/fixtures/newly_supported.ui
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>screen</class>
+ <widget class="QWidget" name="screen">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>newly_supported</string>
+  </property>
+  <widget class="QWidget" name="panel">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>200</width>
+     <height>120</height>
+    </rect>
+   </property>
+   <widget class="PyDMLabel" name="readback">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>20</y>
+      <width>100</width>
+      <height>18</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string>ca://${PREFIX}:RBV</string>
+    </property>
+   </widget>
+  </widget>
+  <widget class="PyDMShellCommand" name="probe">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>150</y>
+     <width>120</width>
+     <height>24</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Probe...</string>
+   </property>
+   <property name="commands" stdset="0">
+    <stringlist>
+     <string>probe ${PREFIX}</string>
+    </stringlist>
+   </property>
+   <property name="showIcon" stdset="0">
+    <bool>false</bool>
+   </property>
+   <property name="alarmSensitiveBorder" stdset="0">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="PyDMWaveformPlot" name="graph">
+   <property name="geometry">
+    <rect>
+     <x>220</x>
+     <y>10</y>
+     <width>260</width>
+     <height>200</height>
+    </rect>
+   </property>
+   <property name="title" stdset="0">
+    <string>Temps</string>
+   </property>
+   <property name="curves">
+    <stringlist>
+     <string>{"y_channel": "${PREFIX}:TEMP", "color": "#e00000", "lineWidth": 1}</string>
+     <string>not valid json</string>
+    </stringlist>
+   </property>
+   <property name="xLabels">
+    <stringlist>
+     <string>Time</string>
+    </stringlist>
+   </property>
+  </widget>
+ </widget>
+</ui>

--- a/tests/ui/test_ir_adapter.py
+++ b/tests/ui/test_ir_adapter.py
@@ -6,6 +6,7 @@ from pydmconverter.ir.schema import validate_screen_json
 from pydmconverter.ui.ir_adapter import ui_file_to_ir
 
 FIXTURE = Path(__file__).parent / "fixtures" / "basic_widgets.ui"
+NEWLY_SUPPORTED = Path(__file__).parent / "fixtures" / "newly_supported.ui"
 EDM_FIXTURE = Path(__file__).parents[1] / "edm" / "fixtures" / "basic_widgets.edl"
 
 
@@ -95,6 +96,42 @@ def test_cross_input_equivalence_with_edm():
     in tests/edm/test_ir_adapter.py).
     """
     assert _structure(ui_file_to_ir(FIXTURE))[:3] == _structure(edm_file_to_ir(EDM_FIXTURE))[:3]
+
+
+def _all_types(node):
+    yield node.type
+    for child in node.children:
+        yield from _all_types(child)
+
+
+def test_newly_supported_classes_have_no_unknown_widgets():
+    """QWidget panels, shell commands, and waveform plots all resolve now."""
+    screen = ui_file_to_ir(NEWLY_SUPPORTED)
+    assert "unknown-widget" not in set(_all_types(screen.root))
+
+
+def test_qwidget_panel_becomes_container_with_child():
+    screen = ui_file_to_ir(NEWLY_SUPPORTED)
+    panel = next(c for c in screen.root.children if c.type == "qwidget-container")
+    assert [child.type for child in panel.children] == ["pv-label"]
+    assert panel.children[0].props["pv"] == "${PREFIX}:RBV"  # ca:// stripped
+
+
+def test_shell_command_maps_label_and_command():
+    screen = ui_file_to_ir(NEWLY_SUPPORTED)
+    shell = next(c for c in screen.root.children if c.type == "shell-command-button")
+    assert shell.props["label"] == "Probe..."
+    assert shell.props["command"] == "probe ${PREFIX}"  # firstOf the commands stringlist
+    assert shell.props["alarmBorder"] is True
+
+
+def test_waveform_plot_parses_curves_and_skips_malformed():
+    screen = ui_file_to_ir(NEWLY_SUPPORTED)
+    plot = next(c for c in screen.root.children if c.type == "waveform-plot")
+    assert plot.props["title"] == "Temps"
+    # the malformed second curve string is dropped; the valid one parses to an object
+    assert plot.props["curves"] == [{"y_channel": "${PREFIX}:TEMP", "color": "#e00000", "lineWidth": 1}]
+    assert plot.props["xLabels"] == ["Time"]
 
 
 def test_scalar_number_parsing_is_tolerant():


### PR DESCRIPTION
## Summary

Three Qt/PyDM classes were falling through to `unknown-widget` when converting `.ui` files, producing "unsupported" warnings on real screens. A scan of the ~810 `cryo-displays` `.ui` files found these were the **only** three unsupported classes in use:

| Class | Uses | Files |
|---|---|---|
| `QWidget` | 1,715 | 810 (all) |
| `PyDMWaveformPlot` | 126 | 54 |
| `PyDMShellCommand` | 121 | 45 |

This adds widget-registry entries so all three resolve on the `.ui` → IR path.

## Changes

- **`qwidget-container.json`** — a non-root `QWidget` maps to a children-preserving container. `group` stays SB-native (no `qtMapping`), preserving its existing invariant/tests; QWidget gets its own id instead.
- **`shell-command-button.json`** — `PyDMShellCommand` → `commands`/`command` → `command` (via `firstOf`), `text` → `label`, `showIcon`, alarm flags.
- **`waveform-plot.json`** — `PyDMWaveformPlot`, plus a new **`parseJsonStrings`** transform in `transforms.py` that JSON-parses the `curves`/`yAxes` stringlist blobs (tolerant: skips malformed entries).

## Tests

- Registry resolution (`test_ir_registry.py`), transform (`test_ir_transforms.py`), and `.ui` adapter (`test_ir_adapter.py`) tests, with a new `newly_supported.ui` fixture.
- Full suite: **329 passed, 1 skipped** (pre-existing skip); `test_transforms_cover_registry` still green.

## Verification

Ran the `.ui` → IR conversion over **all 810** `cryo-displays` `.ui` files: **zero** remaining `unknown-widget` nodes (503+402 QWidget containers, 126 waveform plots, 121 shell buttons resolved).

## Notes / follow-ups

- These three registry JSONs are **local additions ahead of the upstream Beaver snapshot** (`.beaver-snapshot-sha` unchanged) — reconcile when Beaver adds them upstream.
- Companion PR on `canopy-screen-builder` adds the matching editor components (PVShellCommand, PVWaveformPlot via ECharts) and IR import/export mapping.
- Deliberate v1 gaps: `axisColor`/`min*Range` (plot) and `titles`/`allowMultipleExecutions` (shell) are pass-through/deferred.