### PR TITLE
Conversion fidelity: mc-displays batch (labels, rules, fonts, sizing, widget mappings)

### DIFF
--- a/pydmconverter/ir/builder.py
+++ b/pydmconverter/ir/builder.py
@@ -68,12 +68,23 @@ class IRBuilder:
         (default ``""``), so the screen is self-consistent (macros design M2/M9).
         """
         width, height = size
+        # Allocate the root id before children so the canvas stays w-001.
+        root_id = self.ids.widget()
+        children = [self._build_node(node) for node in top_level]
+        # PyDM windows auto-grow/scroll, so children can extend past the root
+        # rect; expand the canvas to encompass them rather than clip.
+        MARGIN = 8
+        max_x, max_y = self._content_extent(children)
+        if max_x + MARGIN > width:
+            width = max_x + MARGIN
+        if max_y + MARGIN > height:
+            height = max_y + MARGIN
         root = WidgetNode(
-            id=self.ids.widget(),
+            id=root_id,
             type=self.root_type,
             props={"width": width, "height": height},
             geometry=Geometry(x=0, y=0, width=width, height=height),
-            children=[self._build_node(node) for node in top_level],
+            children=children,
         )
         declared = macros if macros is not None else self._collect_macros(root)
         return ScreenIR(
@@ -164,6 +175,24 @@ class IRBuilder:
                 )
             )
         return rules
+
+    @staticmethod
+    def _content_extent(nodes: list[WidgetNode]) -> tuple[Number, Number]:
+        """Max (x+width, y+height) over a node tree, ignoring zero-size nodes."""
+        max_x = max_y = 0
+
+        def visit(node: WidgetNode) -> None:
+            nonlocal max_x, max_y
+            g = node.geometry
+            if g.width and g.height:
+                max_x = max(max_x, g.x + g.width)
+                max_y = max(max_y, g.y + g.height)
+            for child in node.children:
+                visit(child)
+
+        for n in nodes:
+            visit(n)
+        return max_x, max_y
 
     @staticmethod
     def _geometry(geom: tuple[Number, Number, Number, Number]) -> Geometry:

--- a/pydmconverter/ir/data/widget-registry/embedded-display.json
+++ b/pydmconverter/ir/data/widget-registry/embedded-display.json
@@ -5,22 +5,21 @@
   "description": "Loads another .screen.json document with optional macro forwarding.",
   "category": "containers",
   "paletteIcon": "embedded-display.svg",
-
   "reactComponent": {
     "name": "EmbeddedDisplay",
     "module": "@canopy/widgets"
   },
-
   "qtMapping": {
     "class": "PyDMEmbeddedDisplay",
     "extends": "QFrame",
     "header": "pydm.widgets.embedded_display"
   },
-
   "propSchema": {
     "$schema": "https://json-schema.org/draft-07/schema",
     "type": "object",
-    "required": ["file"],
+    "required": [
+      "file"
+    ],
     "properties": {
       "file": {
         "type": "string",
@@ -29,26 +28,42 @@
       },
       "macros": {
         "type": "object",
-        "additionalProperties": { "type": "string" },
+        "additionalProperties": {
+          "type": "string"
+        },
         "description": "Macros forwarded to the embedded screen."
       }
     }
   },
-
   "qtPropMap": {
-    "filename": { "to": "file" },
-    "macros": { "to": "macros" }
+    "filename": {
+      "to": "file",
+      "transform": "screenRef"
+    },
+    "macros": {
+      "to": "macros"
+    }
   },
-
   "inspectorSchema": {
     "groups": [
-      { "name": "Source", "fields": ["file"] },
-      { "name": "Macros", "fields": ["macros"] }
+      {
+        "name": "Source",
+        "fields": [
+          "file"
+        ]
+      },
+      {
+        "name": "Macros",
+        "fields": [
+          "macros"
+        ]
+      }
     ]
   },
-
-  "defaults": { "width": 400, "height": 200 },
-
+  "defaults": {
+    "width": 400,
+    "height": 200
+  },
   "supportsPv": false,
   "supportsRules": true,
   "supportsChildren": false

--- a/pydmconverter/ir/data/widget-registry/polygon.json
+++ b/pydmconverter/ir/data/widget-registry/polygon.json
@@ -1,19 +1,19 @@
 {
-  "id": "line",
+  "id": "polygon",
   "version": "1.0.0",
-  "displayName": "Line",
-  "description": "Polyline with optional arrowheads. Vertices are relative to the widget's top-left corner.",
+  "displayName": "Polygon",
+  "description": "Closed polygon from a list of vertices. Vertices are relative to the widget's top-left corner.",
   "category": "drawing",
-  "paletteIcon": "line.svg",
+  "paletteIcon": "polygon.svg",
 
   "reactComponent": {
-    "name": "Line",
+    "name": "Polygon",
     "module": "@canopy/widgets"
   },
 
   "qtMapping": {
-    "class": "PyDMDrawingPolyline",
-    "extends": "QWidget",
+    "class": "PyDMDrawingIrregularPolygon",
+    "extends": "PyDMDrawingPolyline",
     "header": "pydm.widgets.drawing"
   },
 
@@ -41,9 +41,13 @@
         },
         "description": "Vertices relative to the widget's top-left corner."
       },
-      "arrowStart": { "type": "boolean", "default": false },
-      "arrowEnd": { "type": "boolean", "default": false },
-      "arrowSize": { "type": "number", "minimum": 1, "default": 10 },
+      "closed": {
+        "type": "boolean",
+        "default": true,
+        "description": "Whether the outline is closed (polygon) or left open (polyline)."
+      },
+      "fill": { "type": "boolean", "default": false },
+      "fillColor": { "type": "string" },
       "opacity": {
         "type": "number",
         "minimum": 0,
@@ -59,18 +63,18 @@
     "penWidth": { "to": "lineWidth" },
     "penStyle": { "to": "lineStyle", "transform": "edmLineStyle" },
     "points": { "to": "points", "transform": "parsePoints" },
-    "arrowStartPoint": { "to": "arrowStart" },
-    "arrowEndPoint": { "to": "arrowEnd" },
+    "brushFill": { "to": "fill" },
+    "brushColor": { "to": "fillColor" },
     "opacity": { "to": "opacity" }
   },
 
   "inspectorSchema": {
     "groups": [
-      { "name": "Appearance", "fields": ["lineColor", "lineWidth", "lineStyle", "arrowStart", "arrowEnd", "arrowSize", "opacity"] }
+      { "name": "Appearance", "fields": ["lineColor", "lineWidth", "lineStyle", "fill", "fillColor", "opacity"] }
     ]
   },
 
-  "defaults": { "width": 200, "height": 100 },
+  "defaults": { "width": 100, "height": 100 },
 
   "supportsPv": false,
   "supportsRules": true,

--- a/pydmconverter/ir/data/widget-registry/pv-button.json
+++ b/pydmconverter/ir/data/widget-registry/pv-button.json
@@ -31,7 +31,11 @@
       },
       "iconOnly": { "type": "boolean", "default": false },
       "pressValue": { "type": ["number", "string"] },
-      "releaseValue": { "type": ["number", "string"] }
+      "releaseValue": { "type": ["number", "string"] },
+      "fontSize": {
+        "type": "number",
+        "title": "Font Size (px)"
+      }
     }
   },
 
@@ -39,7 +43,8 @@
     "channel": { "to": "pv", "transform": "stripProtocol" },
     "pressValue": { "to": "pressValue" },
     "releaseValue": { "to": "releaseValue" },
-    "text": { "to": "label" }
+    "text": { "to": "label" },
+    "fontSize": { "to": "fontSize" }
   },
 
   "inspectorSchema": {

--- a/pydmconverter/ir/data/widget-registry/pv-enum-combobox.json
+++ b/pydmconverter/ir/data/widget-registry/pv-enum-combobox.json
@@ -24,13 +24,15 @@
     "properties": {
       "pv": { "type": "string", "format": "pv-channel" },
       "searchable": { "type": "boolean", "default": false },
-      "alarmSensitive": { "type": "boolean", "default": false }
+      "alarmSensitive": { "type": "boolean", "default": false },
+      "fontSize": { "type": "number", "title": "Font Size (px)" }
     }
   },
 
   "qtPropMap": {
     "channel": { "to": "pv", "transform": "stripProtocol" },
-    "alarmSensitiveContent": { "to": "alarmSensitive" }
+    "alarmSensitiveContent": { "to": "alarmSensitive" },
+    "fontSize": { "to": "fontSize" }
   },
 
   "inspectorSchema": {

--- a/pydmconverter/ir/data/widget-registry/pv-label.json
+++ b/pydmconverter/ir/data/widget-registry/pv-label.json
@@ -20,13 +20,18 @@
   "propSchema": {
     "$schema": "https://json-schema.org/draft-07/schema",
     "type": "object",
-    "required": ["pv"],
+    "required": [],
     "properties": {
       "pv": {
         "type": "string",
         "title": "PV Channel",
         "description": "EPICS PV name (supports ${MACRO} substitution)",
         "format": "pv-channel"
+      },
+      "text": {
+        "type": "string",
+        "title": "Static Text",
+        "description": "Static fallback text shown when no PV is bound (channel-less PyDMLabel)."
       },
       "precision": {
         "oneOf": [
@@ -44,12 +49,22 @@
         "default": "default"
       },
       "foregroundColor": { "type": "string" },
-      "backgroundColor": { "type": "string" }
+      "backgroundColor": { "type": "string" },
+      "fontSize": {
+        "type": "number",
+        "title": "Font Size (px)"
+      },
+      "align": {
+        "type": "string",
+        "enum": ["left", "center", "right"],
+        "default": "left"
+      }
     }
   },
 
   "qtPropMap": {
     "channel": { "to": "pv", "transform": "stripProtocol" },
+    "text": { "to": "text" },
     "precisionFromPV": { "to": "precision", "transform": "boolToFromPV" },
     "precision": { "to": "precision" },
     "showUnits": { "to": "showUnits" },
@@ -57,7 +72,9 @@
     "alarmSensitiveBorder": { "to": "alarmBorder" },
     "displayFormat": { "to": "format" },
     "foregroundColor": { "to": "foregroundColor" },
-    "backgroundColor": { "to": "backgroundColor" }
+    "backgroundColor": { "to": "backgroundColor" },
+    "fontSize": { "to": "fontSize" },
+    "alignment": { "to": "align", "transform": "qtAlignment" }
   },
 
   "inspectorSchema": {

--- a/pydmconverter/ir/data/widget-registry/pv-radio-group.json
+++ b/pydmconverter/ir/data/widget-registry/pv-radio-group.json
@@ -28,13 +28,18 @@
         "enum": ["horizontal", "vertical"],
         "default": "vertical"
       },
-      "alarmSensitive": { "type": "boolean", "default": false }
+      "alarmSensitive": { "type": "boolean", "default": false },
+      "fontSize": {
+        "type": "number",
+        "title": "Font Size (px)"
+      }
     }
   },
 
   "qtPropMap": {
     "channel": { "to": "pv", "transform": "stripProtocol" },
-    "orientation": { "to": "orientation", "transform": "qtOrientation" }
+    "orientation": { "to": "orientation", "transform": "qtOrientation" },
+    "fontSize": { "to": "fontSize" }
   },
 
   "inspectorSchema": {

--- a/pydmconverter/ir/data/widget-registry/pv-spinbox.json
+++ b/pydmconverter/ir/data/widget-registry/pv-spinbox.json
@@ -1,0 +1,60 @@
+{
+  "id": "pv-spinbox",
+  "version": "1.0.0",
+  "displayName": "PV Spinbox",
+  "description": "Numeric spinbox bound to a PV. Writes the value on change.",
+  "category": "controls",
+  "paletteIcon": "pv-text-input.svg",
+
+  "reactComponent": {
+    "name": "PVSpinbox",
+    "module": "@canopy/widgets"
+  },
+
+  "qtMapping": {
+    "class": "PyDMSpinbox",
+    "extends": "QDoubleSpinBox",
+    "header": "pydm.widgets.spinbox"
+  },
+
+  "propSchema": {
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "type": "object",
+    "required": ["pv"],
+    "properties": {
+      "pv": { "type": "string", "format": "pv-channel" },
+      "precision": { "type": "number", "minimum": 0 },
+      "precisionFromPV": { "type": "boolean", "default": true },
+      "showStepExponent": { "type": "boolean", "default": false },
+      "minValue": { "type": "number" },
+      "maxValue": { "type": "number" },
+      "limitsFromPV": { "type": "boolean", "default": true },
+      "alarmSensitive": { "type": "boolean", "default": false }
+    }
+  },
+
+  "qtPropMap": {
+    "channel": { "to": "pv", "transform": "stripProtocol" },
+    "precision": { "to": "precision" },
+    "precisionFromPV": { "to": "precisionFromPV" },
+    "showStepExponent": { "to": "showStepExponent" },
+    "userMinimum": { "to": "minValue" },
+    "userMaximum": { "to": "maxValue" },
+    "alarmSensitiveContent": { "to": "alarmSensitive" }
+  },
+
+  "inspectorSchema": {
+    "groups": [
+      { "name": "PV", "fields": ["pv", "limitsFromPV"] },
+      { "name": "Display", "fields": ["precision", "precisionFromPV", "showStepExponent"] },
+      { "name": "Limits", "fields": ["minValue", "maxValue"] },
+      { "name": "Alarm", "fields": ["alarmSensitive"] }
+    ]
+  },
+
+  "defaults": { "width": 120, "height": 28 },
+
+  "supportsPv": true,
+  "supportsRules": true,
+  "supportsChildren": false
+}

--- a/pydmconverter/ir/data/widget-registry/pv-text-input.json
+++ b/pydmconverter/ir/data/widget-registry/pv-text-input.json
@@ -30,7 +30,11 @@
       },
       "writeOnEnter": { "type": "boolean", "default": true },
       "placeholder": { "type": "string" },
-      "alarmSensitive": { "type": "boolean", "default": false }
+      "alarmSensitive": { "type": "boolean", "default": false },
+      "fontSize": {
+        "type": "number",
+        "title": "Font Size (px)"
+      }
     }
   },
 
@@ -38,7 +42,8 @@
     "channel": { "to": "pv", "transform": "stripProtocol" },
     "writeOnPress": { "to": "writeOnEnter" },
     "placeholderText": { "to": "placeholder" },
-    "alarmSensitiveContent": { "to": "alarmSensitive" }
+    "alarmSensitiveContent": { "to": "alarmSensitive" },
+    "fontSize": { "to": "fontSize" }
   },
 
   "inspectorSchema": {

--- a/pydmconverter/ir/data/widget-registry/regular-button.json
+++ b/pydmconverter/ir/data/widget-registry/regular-button.json
@@ -39,13 +39,18 @@
           "additionalProperties": true
         },
         "description": "Converter-carried action list (e.g. shell_command, close_display); the Screen Builder lifts these into widget actions."
+      },
+      "fontSize": {
+        "type": "number",
+        "title": "Font Size (px)"
       }
     }
   },
 
   "qtPropMap": {
     "text": { "to": "label" },
-    "actions": { "to": "actions" }
+    "actions": { "to": "actions" },
+    "fontSize": { "to": "fontSize" }
   },
 
   "inspectorSchema": {

--- a/pydmconverter/ir/data/widget-registry/related-display-button.json
+++ b/pydmconverter/ir/data/widget-registry/related-display-button.json
@@ -5,55 +5,100 @@
   "description": "Opens another screen with optional macro forwarding.",
   "category": "controls",
   "paletteIcon": "related-display-button.svg",
-
   "reactComponent": {
     "name": "RelatedDisplayButton",
     "module": "@canopy/widgets"
   },
-
   "qtMapping": {
     "class": "PyDMRelatedDisplayButton",
     "extends": "QPushButton",
     "header": "pydm.widgets.related_display_button"
   },
-
   "propSchema": {
     "$schema": "https://json-schema.org/draft-07/schema",
     "type": "object",
-    "required": ["file"],
+    "required": [
+      "file"
+    ],
     "properties": {
-      "file": { "type": "string", "description": "Path to a .screen.json document." },
-      "label": { "type": "string" },
+      "file": {
+        "type": "string",
+        "description": "Path to a .screen.json document."
+      },
+      "label": {
+        "type": "string"
+      },
       "kind": {
         "type": "string",
-        "enum": ["primary", "secondary", "tertiary", "danger", "ghost"],
+        "enum": [
+          "primary",
+          "secondary",
+          "tertiary",
+          "danger",
+          "ghost"
+        ],
         "default": "tertiary"
       },
       "macros": {
         "type": "object",
-        "additionalProperties": { "type": "string" },
+        "additionalProperties": {
+          "type": "string"
+        },
         "description": "Macros forwarded to the opened screen."
       },
-      "openInNewWindow": { "type": "boolean", "default": false }
+      "openInNewWindow": {
+        "type": "boolean",
+        "default": false
+      },
+      "fontSize": {
+        "type": "number",
+        "title": "Font Size (px)"
+      }
     }
   },
-
   "qtPropMap": {
-    "filenames": { "to": "file", "transform": "firstOf" },
-    "text": { "to": "label" },
-    "macros": { "to": "macros" }
+    "filenames": {
+      "to": "file",
+      "transform": "screenRef"
+    },
+    "text": {
+      "to": "label"
+    },
+    "macros": {
+      "to": "macros"
+    },
+    "fontSize": {
+      "to": "fontSize"
+    }
   },
-
   "inspectorSchema": {
     "groups": [
-      { "name": "Target", "fields": ["file", "macros"] },
-      { "name": "Display", "fields": ["label", "kind"] },
-      { "name": "Behavior", "fields": ["openInNewWindow"] }
+      {
+        "name": "Target",
+        "fields": [
+          "file",
+          "macros"
+        ]
+      },
+      {
+        "name": "Display",
+        "fields": [
+          "label",
+          "kind"
+        ]
+      },
+      {
+        "name": "Behavior",
+        "fields": [
+          "openInNewWindow"
+        ]
+      }
     ]
   },
-
-  "defaults": { "width": 120, "height": 32 },
-
+  "defaults": {
+    "width": 120,
+    "height": 32
+  },
   "supportsPv": false,
   "supportsRules": true,
   "supportsChildren": false

--- a/pydmconverter/ir/data/widget-registry/shell-command-button.json
+++ b/pydmconverter/ir/data/widget-registry/shell-command-button.json
@@ -29,7 +29,11 @@
       "showIcon": { "type": "boolean", "default": false },
       "allowMultipleExecutions": { "type": "boolean", "default": false },
       "alarmSensitive": { "type": "boolean", "default": false },
-      "alarmBorder": { "type": "boolean", "default": false }
+      "alarmBorder": { "type": "boolean", "default": false },
+      "fontSize": {
+        "type": "number",
+        "title": "Font Size (px)"
+      }
     }
   },
 
@@ -40,7 +44,8 @@
     "showIcon": { "to": "showIcon" },
     "allowMultipleExecutions": { "to": "allowMultipleExecutions" },
     "alarmSensitiveContent": { "to": "alarmSensitive" },
-    "alarmSensitiveBorder": { "to": "alarmBorder" }
+    "alarmSensitiveBorder": { "to": "alarmBorder" },
+    "fontSize": { "to": "fontSize" }
   },
 
   "inspectorSchema": {

--- a/pydmconverter/ir/data/widget-registry/text-label.json
+++ b/pydmconverter/ir/data/widget-registry/text-label.json
@@ -33,7 +33,11 @@
         "default": "left"
       },
       "foregroundColor": { "type": "string" },
-      "backgroundColor": { "type": "string" }
+      "backgroundColor": { "type": "string" },
+      "fontSize": {
+        "type": "number",
+        "title": "Font Size (px)"
+      }
     }
   },
 
@@ -41,7 +45,8 @@
     "text": { "to": "text" },
     "alignment": { "to": "align", "transform": "qtAlignment" },
     "foregroundColor": { "to": "foregroundColor" },
-    "backgroundColor": { "to": "backgroundColor" }
+    "backgroundColor": { "to": "backgroundColor" },
+    "fontSize": { "to": "fontSize" }
   },
 
   "inspectorSchema": {

--- a/pydmconverter/ir/macros.py
+++ b/pydmconverter/ir/macros.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 import re
 from typing import Any
 
-# Canonical reference pattern — matches the @canopy/core regex exactly (M6).
-MACRO_REF_RE = re.compile(r"\$\{([A-Z][A-Z0-9_]*)\}")
+# Matches the broad ``\w+`` form the runtime resolver substitutes, so
+# lowercase/mixed-case macros (${dev}, ${signal}) are found rather than dropped.
+# The published @slaclab/canopy-screen-ir contract accepts this case too.
+MACRO_REF_RE = re.compile(r"\$\{(\w+)\}")
 
 # EDM-style ``$(VAR)`` to tolerate on input; normalized to ``${VAR}`` (M1).
 _EDM_MACRO_RE = re.compile(r"\$\(([A-Za-z_][A-Za-z0-9_]*)\)")

--- a/pydmconverter/ir/model.py
+++ b/pydmconverter/ir/model.py
@@ -36,9 +36,10 @@ SchemaVersion = Literal["1.0"]
 ScreenKind = Literal["screen", "template"]
 FormulaKind = Literal["scalar", "timeseries", "waveform"]
 
-# Macro names: uppercase letters/digits/underscores, must start with a letter
-# (Canopy macros design M2). ``${VAR}`` references resolve frontend-side.
-MACRO_NAME_PATTERN = r"^[A-Z][A-Z0-9_]*$"
+# Matches the published @slaclab/canopy-screen-ir contract: accepts lowercase/
+# mixed-case macros (${dev}, ${signal}) that PyDM/EDM sources author, rather than
+# rejecting them here and stranding their PVs.
+MACRO_NAME_PATTERN = r"^[A-Za-z][A-Za-z0-9_]*$"
 
 
 class Geometry(IRModel):

--- a/pydmconverter/ir/transforms.py
+++ b/pydmconverter/ir/transforms.py
@@ -131,6 +131,32 @@ def first_of(value: Any) -> Any:
     return value
 
 
+def screen_ref(value: Any) -> Any:
+    """A PyDM screen reference (``filename``/``filenames``) -> the converted
+    ``.screen.json`` artifact.
+
+    Rewrites only the extension, preserving the directory: subdirs share
+    basenames (``Collimator/Widget`` vs ``Heater/Widget``), so a basename-only
+    ref would collide. Takes the first of a ``filenames`` stringlist; leaves
+    already-``.screen.json`` and macro-only/empty refs alone.
+    """
+    if isinstance(value, (list, tuple)):
+        value = value[0] if value else DROP
+    if value is DROP or not isinstance(value, str) or not value.strip():
+        return DROP if value is DROP else value
+    ref = value.strip().replace("\\", "/")
+    if ref.endswith(".screen.json"):
+        return ref
+    for ext in (".ui", ".edl"):
+        if ref.endswith(ext):
+            return ref[: -len(ext)] + ".screen.json"
+    # Extensionless targets get the extension appended; macro refs can't be
+    # rewritten, so leave them.
+    if "${" in ref or "$(" in ref:
+        return ref
+    return ref + ".screen.json"
+
+
 def edm_line_style(value: Any) -> Any:
     """EDM/Qt pen style -> builder line style ("solid" / "dashed" / "dotted").
 
@@ -170,6 +196,34 @@ def parse_json_strings(value: Any) -> Any:
     return parsed
 
 
+def parse_points(value: Any) -> Any:
+    """A ``stringlist`` of ``"x, y"`` pairs -> a list of ``{"x": float, "y": float}``.
+
+    Polyline/polygon vertices, which the runtime expects as structured objects.
+    Idempotent (already-``{x, y}`` dicts pass through); unparseable entries are
+    skipped rather than raising.
+    """
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, (list, tuple)):
+        return value
+    points: list[Any] = []
+    for item in value:
+        if isinstance(item, dict) and "x" in item and "y" in item:
+            points.append(item)
+            continue
+        if not isinstance(item, str):
+            continue
+        parts = item.replace(",", " ").split()
+        if len(parts) < 2:
+            continue
+        try:
+            points.append({"x": float(parts[0]), "y": float(parts[1])})
+        except (ValueError, TypeError):
+            continue
+    return points
+
+
 TRANSFORMS: dict[str, Callable[[Any], Any]] = {
     "stripProtocol": strip_protocol,
     "boolToFromPV": bool_to_from_pv,
@@ -179,8 +233,10 @@ TRANSFORMS: dict[str, Callable[[Any], Any]] = {
     "qtFrameShadow": qt_frame_shadow,
     "qtScrollPolicy": qt_scroll_policy,
     "firstOf": first_of,
+    "screenRef": screen_ref,
     "edmLineStyle": edm_line_style,
     "parseJsonStrings": parse_json_strings,
+    "parsePoints": parse_points,
 }
 
 

--- a/pydmconverter/ui/ir_adapter.py
+++ b/pydmconverter/ui/ir_adapter.py
@@ -1,19 +1,15 @@
 """Qt ``.ui`` front-end adapter: ``.ui`` XML -> SourceNode tree -> ScreenIR.
 
-Parses a PyDM/Qt Designer ``.ui`` document with ``xml.etree`` and normalizes each
-widget into a :class:`~pydmconverter.ir.source.SourceNode`. Because ``.ui`` carries
-Qt/PyDM class names and Qt property names, the props pass straight to the shared
-:class:`~pydmconverter.ir.builder.IRBuilder` (Beaver's ``qtPropMap`` does the rest)
-— there is no per-attribute translation as on the EDM side.
-
-Geometry (D4): a widget's absolute ``geometry`` ``<rect>`` is trusted. A widget that
-has no ``<rect>`` (e.g. it sits in a Qt layout) gets a warning and ``(0,0,0,0)`` for
-now — computing absolute coordinates from layout managers is a later refinement
-("trust ``<rect>``, warn when computing").
+Qt/PyDM class and property names pass straight to the shared :class:`IRBuilder`
+(the registry's ``qtPropMap`` does the translation); there is no per-attribute
+mapping as on the EDM side. A widget's absolute ``geometry`` ``<rect>`` is
+trusted; one without a rect (e.g. inside a Qt layout) warns and gets ``(0,0,0,0)``.
 """
 
 from __future__ import annotations
 
+import json
+import re
 import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any
@@ -21,9 +17,122 @@ from typing import Any
 from pydmconverter.ir.builder import IRBuilder
 from pydmconverter.ir.model import ScreenIR
 from pydmconverter.ir.registry import RegistryClient, VendoredRegistry
-from pydmconverter.ir.source import SourceNode
+from pydmconverter.ir.source import RuleSpec, SourceNode
 
 _SKIP = object()
+
+# Rewrite synonym source classes to a canonical class the registry already
+# knows, before lookup, so the builder resolves an existing IR type instead of
+# emitting unknown-widget. Each target reuses an existing entry's qtPropMap
+# verbatim. Classes needing their own prop translation get a dedicated registry
+# entry instead (e.g. PyDMSpinbox -> pv-spinbox).
+_QT_CLASS_ALIASES = {
+    "PyDMEDMDisplayButton": "PyDMRelatedDisplayButton",
+    "PyDMFrame": "QFrame",
+    "Line": "PyDMDrawingPolyline",
+    "PyDMDrawingLine": "PyDMDrawingPolyline",
+    # No-PV text widgets degrade to a static text-label; authored text survives.
+    "QTextEdit": "QLabel",
+    "QTextBrowser": "QLabel",
+    "QLineEdit": "QLabel",
+    # Multi-page containers degrade to tabs; children and z-order survive.
+    "QStackedWidget": "QTabWidget",
+    "QToolBox": "QTabWidget",
+    "PyDMTabWidget": "QTabWidget",
+    "PyDMDrawingPie": "PyDMDrawingArc",  # renders as an outlined arc, not a filled wedge
+    "PyDMDrawingTriangle": "PyDMDrawingIrregularPolygon",
+    "PyDMDrawingCircle": "PyDMDrawingEllipse",
+    "PyDMTimePlot": "PyDMWaveformPlot",  # time axis degrades to sample index
+    "PyDMEventPlot": "PyDMWaveformPlot",
+    "QComboBox": "PyDMEnumComboBox",
+    "QSpinBox": "PyDMSpinbox",
+}
+
+# PyDM rule ``property`` -> IR target_property. Visibility is by far the common case.
+_PYDM_RULE_PROPERTY_MAP = {
+    "Visible": "visible",
+    "Enable": "enabled",
+    "Opacity": "opacity",
+    "Text Color": "foregroundColor",
+    "foregroundColor": "foregroundColor",
+}
+
+# Boolean targets whose ``initial_value`` string is coerced to a real bool.
+_BOOLEAN_RULE_TARGETS = {"visible", "enabled"}
+
+_CH_TOKEN = re.compile(r"ch\[\s*(\d+)\s*\]")
+_CHANNEL_PREFIX = re.compile(r"^(?:ca|pva)://")
+
+
+def _wire_expression(expression: str) -> str:
+    """Translate a PyDM expression (``ch[0]``) to IR wire form (``{0}``)."""
+    return _CH_TOKEN.sub(lambda m: "{" + m.group(1) + "}", expression or "")
+
+
+def _coerce_default(initial_value: Any, target_property: str) -> Any:
+    """Convert a PyDM rule ``initial_value`` to the right type for the target."""
+    if target_property in _BOOLEAN_RULE_TARGETS:
+        if isinstance(initial_value, bool):
+            return initial_value
+        if isinstance(initial_value, (int, float)):
+            return bool(initial_value)
+        if isinstance(initial_value, str):
+            token = initial_value.strip().lower()
+            if token in ("1", "true"):
+                return True
+            if token in ("0", "false"):
+                return False
+        return False
+    return initial_value
+
+
+def _parse_rules(rules_text: str | None, warnings: list[str]) -> list[RuleSpec]:
+    """Parse a PyDM ``rules`` property JSON string into :class:`RuleSpec`s.
+
+    Never raises: a missing/empty prop or malformed JSON yields ``[]`` (+ warning).
+    """
+    if not rules_text or not rules_text.strip():
+        return []
+    try:
+        raw = json.loads(rules_text)
+    except (ValueError, TypeError):
+        warnings.append("could not parse PyDM 'rules' property (malformed JSON); dropped rules")
+        return []
+    if not isinstance(raw, list):
+        warnings.append("PyDM 'rules' property is not a JSON array; dropped rules")
+        return []
+
+    specs: list[RuleSpec] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        pydm_prop = entry.get("property", "Visible")
+        target = _PYDM_RULE_PROPERTY_MAP.get(pydm_prop)
+        if target is None:
+            target = (pydm_prop[:1].lower() + pydm_prop[1:]) if pydm_prop else "visible"
+            warnings.append(f"unknown PyDM rule property {pydm_prop!r}; mapped to {target!r} as best effort")
+
+        pv_index: dict[str, int] = {}
+        pvs: list[tuple[str, bool]] = []
+        for chan in entry.get("channels", []) or []:
+            if not isinstance(chan, dict):
+                continue
+            name = _CHANNEL_PREFIX.sub("", str(chan.get("channel", "")))
+            if name not in pv_index:
+                pv_index[name] = len(pvs)
+                pvs.append((name, bool(chan.get("trigger", False))))
+
+        wire = _wire_expression(entry.get("expression", ""))
+        specs.append(
+            RuleSpec(
+                target_property=target,
+                name=entry.get("name") or "Rule",
+                pvs=pvs,
+                conditions=[(wire, True)],
+                default=_coerce_default(entry.get("initial_value"), target),
+            )
+        )
+    return specs
 
 
 def _parse_int(text: str) -> Any:
@@ -50,11 +159,8 @@ def _parse_float(text: str) -> Any:
 
 
 def _scalar_property(prop: ET.Element) -> Any:
-    """Extract a scalar value from a ``<property>``; ``_SKIP`` for unsupported kinds.
-
-    Handles the simple typed children. Complex kinds (font, sizepolicy, ...) are
-    skipped — no supported prop consumes them.
-    """
+    """Extract a scalar value from a ``<property>``; ``_SKIP`` for complex kinds
+    (font, sizepolicy, ...) that no supported prop consumes."""
     children = list(prop)
     if not children:
         return _SKIP
@@ -74,6 +180,28 @@ def _scalar_property(prop: ET.Element) -> Any:
     if tag == "stringlist":
         return [c.text or "" for c in el]
     return _SKIP
+
+
+def _font_pixels(prop: ET.Element) -> int | None:
+    """Pixel font size from a Qt ``<font>``: ``<pixelsize>`` verbatim, else
+    ``<pointsize>`` converted at 96 DPI (``pt * 96/72``). ``None`` if absent or
+    unparseable — never raises."""
+    font = prop.find("font")
+    if font is None:
+        return None
+    pixel_el = font.find("pixelsize")
+    if pixel_el is not None and pixel_el.text and pixel_el.text.strip():
+        try:
+            return int(pixel_el.text.strip())
+        except ValueError:
+            return None
+    point_el = font.find("pointsize")
+    if point_el is not None and point_el.text and point_el.text.strip():
+        try:
+            return round(int(point_el.text.strip()) * 96 / 72)
+        except ValueError:
+            return None
+    return None
 
 
 def _rect(prop: ET.Element) -> tuple[int, int, int, int] | None:
@@ -110,35 +238,178 @@ def _layout_widgets(layout: ET.Element) -> list[ET.Element]:
     return found
 
 
-def _widget_to_source(widget: ET.Element) -> SourceNode:
-    qt_class = widget.get("class")
+def _template_root_size(path: Path) -> tuple[int, int] | None:
+    """Width/height of a template ``.ui``'s root geometry rect — the per-instance
+    footprint used to lay out repeater rows/columns. ``None`` if unreadable."""
+    try:
+        root_widget = ET.parse(path).getroot().find("widget")
+    except (ET.ParseError, OSError):
+        return None
+    if root_widget is None:
+        return None
+    for prop in root_widget.findall("property"):
+        if prop.get("name") == "geometry":
+            rect = _rect(prop)
+            if rect:
+                return (rect[2], rect[3])
+    return None
+
+
+def _expand_template_repeater(
+    props: dict[str, Any],
+    geometry: tuple[int, int, int, int],
+    source_dir: Path | None,
+    warnings: list[str],
+) -> list[SourceNode] | None:
+    """Materialize a ``PyDMTemplateRepeater`` into one embedded-display per record.
+
+    Each record in ``dataSource`` (a JSON list of macro dicts) becomes an
+    embedded-display of the converted template, carrying the record as its
+    ``macros`` and stepped along the repeater's rect by the template size +
+    spacing. ``None`` (falls back to unknown-widget) if the dataSource is
+    missing/unreadable/not-a-list.
+    """
+    template = props.get("templateFilename")
+    data_source = props.get("dataSource")
+    if not isinstance(template, str) or not template.strip():
+        warnings.append("PyDMTemplateRepeater has no templateFilename; rendering placeholder")
+        return None
+    if not isinstance(data_source, str) or not data_source.strip():
+        warnings.append("PyDMTemplateRepeater has no dataSource; rendering placeholder")
+        return None
+    if source_dir is None:
+        warnings.append("PyDMTemplateRepeater: source directory unknown, cannot resolve dataSource; placeholder")
+        return None
+
+    def _resolve(ref: str) -> Path:
+        """Resolve a repeater path against the source dir, falling back to the
+        basename when a deploy-time env prefix (``$PYDM/mc/...``) won't resolve."""
+        p = (source_dir / ref).resolve()
+        if p.exists():
+            return p
+        base = ref.replace("\\", "/").rsplit("/", 1)[-1]
+        alt = (source_dir / base).resolve()
+        return alt if alt.exists() else p
+
+    data_path = _resolve(data_source)
+    try:
+        records = json.loads(data_path.read_text())
+    except (OSError, ValueError, TypeError):
+        warnings.append(f"PyDMTemplateRepeater dataSource {data_source!r} missing/unreadable; rendering placeholder")
+        return None
+    if not isinstance(records, list):
+        warnings.append(f"PyDMTemplateRepeater dataSource {data_source!r} is not a JSON list; rendering placeholder")
+        return None
+
+    # Fall back to the repeater rect if the template can't be sized.
+    tmpl_path = _resolve(template)
+    tmpl_size = _template_root_size(tmpl_path)
+    if tmpl_size is None:
+        warnings.append(f"PyDMTemplateRepeater template {template!r} unreadable; using repeater rect for instance size")
+        tmpl_w, tmpl_h = geometry[2], geometry[3]
+    else:
+        tmpl_w, tmpl_h = tmpl_size
+
+    layout = str(props.get("layoutType", "")).lower()
+    horizontal = "horizontal" in layout  # absent -> Vertical (PyDM default)
+    spacing = props.get("layoutSpacing", 0)
+    if not isinstance(spacing, int):
+        spacing = 0
+
+    base_x, base_y = geometry[0], geometry[1]
+    # Keep the relative path, not just the basename: subdirs share basenames
+    # (Collimator/Widget vs Heater/Widget), so screenRef needs the dir to
+    # resolve the right converted template.
+    template_ref = template.strip().replace("\\", "/")
+    # If the literal path didn't resolve but its basename did, emit the basename.
+    if not (source_dir / template_ref).exists() and tmpl_path.name == template_ref.rsplit("/", 1)[-1]:
+        if tmpl_path.exists():
+            template_ref = tmpl_path.name
+
+    nodes: list[SourceNode] = []
+    for i, record in enumerate(records):
+        macros = record if isinstance(record, dict) else {}
+        if horizontal:
+            x = base_x + i * (tmpl_w + spacing)
+            y = base_y
+        else:
+            x = base_x
+            y = base_y + i * (tmpl_h + spacing)
+        nodes.append(
+            SourceNode(
+                qt_class="PyDMEmbeddedDisplay",
+                qt_props={"filename": template_ref, "macros": macros},
+                geometry=(x, y, tmpl_w, tmpl_h),
+                raw_class="PyDMTemplateRepeater",
+                raw_props={"filename": template_ref, "macros": macros},
+                warnings=list(warnings) if i == 0 else [],
+            )
+        )
+    return nodes
+
+
+def _widget_to_sources(widget: ET.Element, source_dir: Path | None) -> list[SourceNode]:
+    """Normalize one ``<widget>`` into one *or more* SourceNodes.
+
+    Almost every widget yields a single node; a ``PyDMTemplateRepeater`` fans out
+    into one embedded-display per dataSource record (falling back to a single
+    unknown-widget node if the dataSource can't be resolved).
+    """
+    raw_class = widget.get("class")
+    qt_class = _QT_CLASS_ALIASES.get(raw_class, raw_class)  # raw_class kept for provenance
     props: dict[str, Any] = {}
     geometry: tuple[int, int, int, int] | None = None
+    rules_text: str | None = None
     for prop in widget.findall("property"):
         name = prop.get("name")
         if name == "geometry":
             geometry = _rect(prop)
+            continue
+        if name == "rules":
+            # A JSON string; parsed separately so it never leaks into qt_props.
+            value = _scalar_property(prop)
+            rules_text = value if isinstance(value, str) else None
+            continue
+        if name == "font":
+            # Reduce the complex <font> to a synthetic fontSize prop; drop the rest.
+            px = _font_pixels(prop)
+            if px is not None:
+                props["fontSize"] = px
             continue
         value = _scalar_property(prop)
         if value is not _SKIP and name:
             props[name] = value
 
     warnings: list[str] = []
+    rules = _parse_rules(rules_text, warnings)
     if geometry is None:
         warnings.append(
-            f"{widget.get('name') or qt_class} has no geometry rect (likely in a Qt layout); using (0,0,0,0)"
+            f"{widget.get('name') or raw_class} has no geometry rect (likely in a Qt layout); using (0,0,0,0)"
         )
         geometry = (0, 0, 0, 0)
 
-    return SourceNode(
-        qt_class=qt_class,
-        qt_props=props,
-        geometry=geometry,
-        raw_class=qt_class,
-        raw_props=dict(props),
-        children=[_widget_to_source(child) for child in _child_widgets(widget)],
-        warnings=warnings,
-    )
+    if raw_class == "PyDMTemplateRepeater":
+        expanded = _expand_template_repeater(props, geometry, source_dir, warnings)
+        if expanded is not None:
+            return expanded
+        # else fall through to the unknown-widget placeholder below
+
+    children: list[SourceNode] = []
+    for child in _child_widgets(widget):
+        children.extend(_widget_to_sources(child, source_dir))
+
+    return [
+        SourceNode(
+            qt_class=qt_class,
+            qt_props=props,
+            geometry=geometry,
+            raw_class=raw_class,
+            raw_props=dict(props),
+            children=children,
+            rules=rules,
+            warnings=warnings,
+        )
+    ]
 
 
 def _string_property(widget: ET.Element, name: str) -> str | None:
@@ -170,7 +441,10 @@ def ui_file_to_ir(input_path: str | Path, *, registry: RegistryClient | None = N
     """Parse a ``.ui`` file and build its Screen IR."""
     path = Path(input_path)
     root_widget, title, size = parse_ui(path)
-    top_level = [_widget_to_source(child) for child in _child_widgets(root_widget)]
+    source_dir = path.parent
+    top_level: list[SourceNode] = []
+    for child in _child_widgets(root_widget):
+        top_level.extend(_widget_to_sources(child, source_dir))
     builder = IRBuilder(registry or VendoredRegistry())
     return builder.build_screen(
         screen_id=path.stem,

--- a/tests/edm/test_byte_and_related.py
+++ b/tests/edm/test_byte_and_related.py
@@ -19,7 +19,7 @@ def test_byte_class_to_pv_byte_led():
 def test_related_display_class():
     """displayFileName list -> file (firstOf); buttonLabel -> label; symbols -> macros."""
     rel = _by_type()["related-display-button"]
-    assert rel.props == {"file": "subscreen", "label": "Open", "macros": {"DEV": "${P}"}}
+    assert rel.props == {"file": "subscreen.screen.json", "label": "Open", "macros": {"DEV": "${P}"}}
 
 
 def test_screen_validates():

--- a/tests/ir/test_ir_builder.py
+++ b/tests/ir/test_ir_builder.py
@@ -52,6 +52,17 @@ def test_pv_label_prop_mapping_and_transform():
     assert label.geometry.model_dump() == {"x": 10, "y": 20, "width": 200, "height": 30}
 
 
+def test_pv_label_alignment_maps_to_align():
+    """PyDMLabel alignment=Qt::AlignCenter -> pv-label align="center" (qtAlignment)."""
+    node = SourceNode(
+        qt_class="PyDMLabel",
+        qt_props={"text": "Horizontal Motors", "alignment": "Qt::AlignCenter"},
+    )
+    label = _screen([node]).root.children[0]
+    assert label.type == "pv-label"
+    assert label.props == {"text": "Horizontal Motors", "align": "center"}
+
+
 def test_bool_to_from_pv_true_and_false():
     true_node = SourceNode(qt_class="PyDMLabel", qt_props={"precisionFromPV": True})
     assert _screen([true_node]).root.children[0].props == {"precision": "fromPV"}
@@ -103,7 +114,7 @@ def test_nested_children():
     outer = SourceNode(qt_class="PyDMEmbeddedDisplay", qt_props={"filename": "child.ui"}, children=[inner])
     node = _screen([outer]).root.children[0]
     assert node.type == "embedded-display"
-    assert node.props == {"file": "child.ui"}
+    assert node.props == {"file": "child.screen.json"}
     assert node.children[0].type == "pv-label"
 
 
@@ -222,3 +233,22 @@ def test_built_screen_validates_and_round_trips():
     from pydmconverter.ir.model import ScreenIR
 
     assert to_json(ScreenIR.model_validate(wire)) == to_json(screen)
+
+
+def test_screen_size_expands_to_encompass_children():
+    """metadata.size grows so children extending past the root rect aren't
+    clipped (convert-fidelity defect O: PyDM windows auto-grow/scroll)."""
+    from pydmconverter.ir.builder import IRBuilder
+    from pydmconverter.ir.registry import VendoredRegistry
+    from pydmconverter.ir.source import SourceNode
+
+    b = IRBuilder(VendoredRegistry())
+    # child reaches x+w=790, y+h=200; declared window is only 710x100
+    child = SourceNode(qt_class="QLabel", qt_props={"text": "x"}, geometry=(10, 10, 780, 190))
+    ir = b.build_screen(screen_id="t", title="t", source_type="ui-converter", size=(710, 100), top_level=[child])
+    assert ir.metadata.size.width >= 790  # +margin
+    assert ir.metadata.size.height >= 200
+    # a screen whose children fit is left unchanged
+    small = SourceNode(qt_class="QLabel", qt_props={"text": "x"}, geometry=(10, 10, 100, 20))
+    ir2 = b.build_screen(screen_id="t2", title="t", source_type="ui-converter", size=(710, 500), top_level=[small])
+    assert (ir2.metadata.size.width, ir2.metadata.size.height) == (710, 500)

--- a/tests/ir/test_ir_model.py
+++ b/tests/ir/test_ir_model.py
@@ -59,12 +59,23 @@ def test_float_geometry_allowed():
 
 
 def test_macro_name_pattern_enforced():
-    """Macro names must match ^[A-Z][A-Z0-9_]*$ (M2)."""
+    """Macro names must start with a letter, then letters/digits/underscores.
+
+    Both cases are accepted: Canopy macros design M2 specifies uppercase, but
+    PyDM/EDM sources author lowercase/mixed-case macros (${dev}, ${signal}, …)
+    which the runtime resolves fine, so the converter preserves the authored
+    spelling rather than dropping the declaration (convert-fidelity defect G).
+    """
     MacroDeclaration(name="PREFIX", default="")
-    with pytest.raises(ValidationError):
-        MacroDeclaration(name="lowercase", default="")
+    # Lowercase and mixed-case are now valid (case preserved).
+    assert MacroDeclaration(name="lowercase", default="").name == "lowercase"
+    assert MacroDeclaration(name="dev", default="").name == "dev"
+    assert MacroDeclaration(name="signalName", default="").name == "signalName"
+    # Still must start with a letter.
     with pytest.raises(ValidationError):
         MacroDeclaration(name="1BAD", default="")
+    with pytest.raises(ValidationError):
+        MacroDeclaration(name="_bad", default="")
 
 
 def test_screen_macro_requires_default():

--- a/tests/ir/test_ir_transforms.py
+++ b/tests/ir/test_ir_transforms.py
@@ -24,6 +24,30 @@ def test_bool_to_from_pv():
     assert apply_transform("boolToFromPV", "false") is DROP
 
 
+def test_parse_points():
+    # "x, y" stringlist -> structured {x, y} floats
+    assert apply_transform("parsePoints", ["0.0, 0.0", "7.0, 5.0", "14.0, 0.0"]) == [
+        {"x": 0.0, "y": 0.0},
+        {"x": 7.0, "y": 5.0},
+        {"x": 14.0, "y": 0.0},
+    ]
+    # tolerant of spacing variants and negatives
+    assert apply_transform("parsePoints", ["1,2", " -3 , 4 "]) == [
+        {"x": 1.0, "y": 2.0},
+        {"x": -3.0, "y": 4.0},
+    ]
+    # a lone string is wrapped
+    assert apply_transform("parsePoints", "5, 6") == [{"x": 5.0, "y": 6.0}]
+    # unparseable entries are skipped, not fatal
+    assert apply_transform("parsePoints", ["1, 2", "junk", "3, 4"]) == [
+        {"x": 1.0, "y": 2.0},
+        {"x": 3.0, "y": 4.0},
+    ]
+    # idempotent: already-structured points pass through
+    already = [{"x": 1.0, "y": 2.0}]
+    assert apply_transform("parsePoints", already) == already
+
+
 def test_qt_orientation():
     assert apply_transform("qtOrientation", "Qt::Horizontal") == "horizontal"
     assert apply_transform("qtOrientation", "Qt::Vertical") == "vertical"
@@ -104,3 +128,22 @@ def test_transforms_cover_registry():
                 referenced.add(entry["transform"])
     missing = referenced - set(known_transforms())
     assert not missing, f"registry references transforms with no implementation: {sorted(missing)}"
+
+
+def test_screen_ref_rewrites_to_screen_json():
+    from pydmconverter.ir.transforms import screen_ref, DROP
+
+    # .ui / .edl -> .screen.json, RELATIVE DIR PRESERVED (subdir templates share
+    # basenames — Collimator/Widget vs Heater/Widget — so the dir must survive).
+    assert screen_ref("motor-simple.ui") == "motor-simple.screen.json"
+    assert screen_ref("sub/dir/foo.edl") == "sub/dir/foo.screen.json"
+    assert screen_ref("Collimator/Widget.ui") == "Collimator/Widget.screen.json"
+    # filenames stringlist -> first, rewritten
+    assert screen_ref(["a.ui", "b.ui"]) == "a.screen.json"
+    # extensionless PyDM related-display target -> append
+    assert screen_ref("mc_li21_coll") == "mc_li21_coll.screen.json"
+    # already-converted / macro refs left sensible
+    assert screen_ref("x.screen.json") == "x.screen.json"
+    assert screen_ref("${SCREEN}") == "${SCREEN}"
+    # empty list drops
+    assert screen_ref([]) is DROP

--- a/tests/test_ui_rules.py
+++ b/tests/test_ui_rules.py
@@ -1,0 +1,89 @@
+"""Tests for PyDM ``.ui`` ``rules`` property -> IR RuleSpec parsing (Defect B)."""
+
+from __future__ import annotations
+
+import json
+
+from pydmconverter.ui.ir_adapter import ui_file_to_ir
+
+
+def _ui_with_rules(rules_text: str) -> str:
+    """A minimal ``.ui`` document with one PyDMLabel carrying the given rules string."""
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect><x>0</x><y>0</y><width>400</width><height>300</height></rect>
+  </property>
+  <widget class="PyDMLabel" name="label">
+   <property name="geometry">
+    <rect><x>10</x><y>20</y><width>100</width><height>30</height></rect>
+   </property>
+   <property name="rules">
+    <string>{rules_text}</string>
+   </property>
+  </widget>
+ </widget>
+</ui>
+"""
+
+
+def _first_label(ir):
+    """The PyDMLabel resolves to the registry's ``pv-label`` widget type."""
+
+    def walk(node):
+        if node.type == "pv-label":
+            return node
+        for child in node.children:
+            found = walk(child)
+            if found is not None:
+                return found
+        return None
+
+    return walk(ir.root)
+
+
+def test_visibility_rule_parsed(tmp_path):
+    rules = [
+        {
+            "name": "Visibility",
+            "property": "Visible",
+            "initial_value": "1",
+            "expression": "ch[0] == 0",
+            "channels": [{"channel": "ca://${DEV}:HomeStatus", "trigger": True, "use_enum": False}],
+        }
+    ]
+    # XML-escape the JSON by using html entities for quotes; simplest is to embed raw
+    # (the ElementTree parser handles double quotes inside element text fine).
+    rules_text = json.dumps(rules).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    ui_path = tmp_path / "vis.ui"
+    ui_path.write_text(_ui_with_rules(rules_text))
+
+    ir = ui_file_to_ir(ui_path)
+    label = _first_label(ir)
+    assert label is not None, "expected a PyDMLabel node in the IR"
+
+    assert len(label.rules) == 1
+    rule = label.rules[0]
+    assert rule.target_property == "visible"
+    assert len(rule.pvs) == 1
+    assert rule.pvs[0].name == "${DEV}:HomeStatus"  # ca:// stripped, macro intact
+    assert rule.pvs[0].trigger is True
+    assert len(rule.conditions) == 1
+    assert rule.conditions[0].expression == "{0} == 0"
+    assert rule.conditions[0].value is True
+    assert rule.default is True  # initial_value "1" -> True for a visible target
+
+    # The raw rules JSON must NOT leak into props.
+    assert "rules" not in label.props
+
+
+def test_malformed_rules_do_not_crash(tmp_path):
+    ui_path = tmp_path / "bad.ui"
+    ui_path.write_text(_ui_with_rules("this is not valid json {["))
+
+    ir = ui_file_to_ir(ui_path)
+    label = _first_label(ir)
+    assert label is not None
+    assert len(label.rules) == 0
+    assert any("rules" in w.lower() for w in label.warnings), "expected a warning about dropped rules"

--- a/tests/ui/test_byte_and_related.py
+++ b/tests/ui/test_byte_and_related.py
@@ -29,7 +29,7 @@ def test_byte_led_props():
 
 def test_related_display_firstof_and_label():
     """filenames stringlist -> file via firstOf; text -> label."""
-    assert _by_type()["related-display-button"].props == {"file": "sub.ui", "label": "Open"}
+    assert _by_type()["related-display-button"].props == {"file": "sub.screen.json", "label": "Open"}
 
 
 def test_frame_enum_transforms():

--- a/tests/ui/test_ir_adapter.py
+++ b/tests/ui/test_ir_adapter.py
@@ -79,6 +79,84 @@ def test_layout_child_without_rect_warns(tmp_path):
     assert label.warnings and "no geometry rect" in label.warnings[0]
 
 
+def test_channelless_pydmlabel_keeps_static_text(tmp_path):
+    """A PyDMLabel with `text` and no `channel` is a static label: the text must survive.
+
+    Regression for Defect A — pv-label dropped `text`, rendering a blank box.
+    """
+    ui = """<?xml version="1.0"?>
+    <ui version="4.0"><widget class="QWidget" name="screen">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>100</width><height>100</height></rect></property>
+      <widget class="PyDMLabel" name="static_lbl">
+        <property name="geometry"><rect><x>5</x><y>5</y><width>80</width><height>20</height></rect></property>
+        <property name="text"><string>Hello</string></property>
+      </widget>
+    </widget></ui>"""
+    path = tmp_path / "static_label.ui"
+    path.write_text(ui, encoding="utf-8")
+    label = ui_file_to_ir(path).root.children[0]
+    assert label.type == "pv-label"
+    assert label.props.get("text") == "Hello"
+    assert "pv" not in label.props
+
+
+def test_irregular_polygon_maps_to_polygon_with_points(tmp_path):
+    """A PyDMDrawingIrregularPolygon becomes a `polygon` node (not unknown-widget),
+    carrying its vertices as structured {x, y} points."""
+    ui = """<?xml version="1.0"?>
+    <ui version="4.0"><widget class="QWidget" name="screen">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>100</width><height>100</height></rect></property>
+      <widget class="PyDMDrawingIrregularPolygon" name="poly">
+        <property name="geometry"><rect><x>5</x><y>5</y><width>20</width><height>20</height></rect></property>
+        <property name="penStyle"><enum>Qt::SolidLine</enum></property>
+        <property name="penWidth"><double>2.0</double></property>
+        <property name="points">
+          <stringlist>
+            <string>0.0, 0.0</string>
+            <string>7.0, 5.0</string>
+            <string>14.0, 0.0</string>
+            <string>0.0, 0.0</string>
+          </stringlist>
+        </property>
+      </widget>
+    </widget></ui>"""
+    path = tmp_path / "poly.ui"
+    path.write_text(ui, encoding="utf-8")
+    node = ui_file_to_ir(path).root.children[0]
+    assert node.type == "polygon"
+    assert node.props["lineWidth"] == 2.0
+    assert node.props["lineStyle"] == "solid"
+    assert node.props["points"] == [
+        {"x": 0.0, "y": 0.0},
+        {"x": 7.0, "y": 5.0},
+        {"x": 14.0, "y": 0.0},
+        {"x": 0.0, "y": 0.0},
+    ]
+
+
+def test_polyline_line_points_are_structured(tmp_path):
+    """A PyDMDrawingPolyline stays a `line` node, and its "x, y" stringlist is
+    normalized to structured {x, y} points (regression: raw strings reached the runtime)."""
+    ui = """<?xml version="1.0"?>
+    <ui version="4.0"><widget class="QWidget" name="screen">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>100</width><height>100</height></rect></property>
+      <widget class="PyDMDrawingPolyline" name="pl">
+        <property name="geometry"><rect><x>0</x><y>0</y><width>20</width><height>20</height></rect></property>
+        <property name="points">
+          <stringlist>
+            <string>0.0, 1.0</string>
+            <string>17.0, 18.0</string>
+          </stringlist>
+        </property>
+      </widget>
+    </widget></ui>"""
+    path = tmp_path / "polyline.ui"
+    path.write_text(ui, encoding="utf-8")
+    node = ui_file_to_ir(path).root.children[0]
+    assert node.type == "line"
+    assert node.props["points"] == [{"x": 0.0, "y": 1.0}, {"x": 17.0, "y": 18.0}]
+
+
 def _structure(screen):
     return [
         (c.type, c.props.get("pv") or c.props.get("text"), tuple(c.geometry.model_dump().values()))
@@ -151,3 +229,98 @@ def test_scalar_number_parsing_is_tolerant():
     assert _scalar_property(prop("number", "nope")) is _SKIP
     assert _scalar_property(prop("double", "1.5")) == 1.5
     assert _scalar_property(prop("double", "nope")) is _SKIP
+
+
+def test_lowercase_macros_are_declared(tmp_path):
+    """Lowercase/mixed-case ${macro} refs in PV channels must be collected into
+    the screen's macros[] (convert-fidelity defect G) — not silently dropped."""
+    from pydmconverter.ui.ir_adapter import ui_file_to_ir
+
+    ui = tmp_path / "lc.ui"
+    ui.write_text(
+        """<?xml version="1.0"?>
+<ui version="4.0"><class>Form</class>
+<widget class="QWidget" name="centralwidget">
+ <property name="geometry"><rect><x>0</x><y>0</y><width>200</width><height>100</height></rect></property>
+ <widget class="PyDMLabel" name="l1">
+  <property name="geometry"><rect><x>0</x><y>0</y><width>100</width><height>20</height></rect></property>
+  <property name="channel"><string>${dev}:${area}:Value</string></property>
+ </widget>
+</widget></ui>"""
+    )
+    ir = ui_file_to_ir(ui)
+    names = {m.name for m in ir.macros}
+    assert "dev" in names and "area" in names
+
+
+def test_font_pointsize_becomes_fontsize_px(tmp_path):
+    """Qt <font><pointsize> is dropped by the scalar walk (complex kind); the adapter
+    must lower it to a px `fontSize` prop so dense text does not overflow at the
+    runtime 13px default (convert-fidelity font defect). px = round(pt * 96/72)."""
+    from pydmconverter.ui.ir_adapter import ui_file_to_ir
+
+    ui = tmp_path / "font.ui"
+    ui.write_text(
+        """<?xml version="1.0"?>
+<ui version="4.0"><class>Form</class>
+<widget class="QWidget" name="centralwidget">
+ <property name="geometry"><rect><x>0</x><y>0</y><width>200</width><height>100</height></rect></property>
+ <widget class="PyDMLabel" name="lbl">
+  <property name="geometry"><rect><x>0</x><y>0</y><width>80</width><height>20</height></rect></property>
+  <property name="text"><string>Currently:</string></property>
+  <property name="font"><font><family>Helvetica</family><pointsize>9</pointsize></font></property>
+ </widget>
+ <widget class="PyDMPushButton" name="btn">
+  <property name="geometry"><rect><x>0</x><y>30</y><width>50</width><height>30</height></rect></property>
+  <property name="text"><string>STOP</string></property>
+  <property name="font"><font><family>Helvetica</family><pointsize>7</pointsize></font></property>
+ </widget>
+</widget></ui>"""
+    )
+    ir = ui_file_to_ir(ui)
+    label, button = ir.root.children[0], ir.root.children[1]
+    assert label.props["fontSize"] == 12  # 9 * 96/72 == 12
+    assert button.props["fontSize"] == 9  # round(7 * 96/72) == 9
+
+
+def test_font_pixelsize_used_verbatim(tmp_path):
+    """A Qt <font><pixelsize> is already in px and is carried through unchanged."""
+    from pydmconverter.ui.ir_adapter import ui_file_to_ir
+
+    ui = tmp_path / "px.ui"
+    ui.write_text(
+        """<?xml version="1.0"?>
+<ui version="4.0"><class>Form</class>
+<widget class="QWidget" name="centralwidget">
+ <property name="geometry"><rect><x>0</x><y>0</y><width>200</width><height>100</height></rect></property>
+ <widget class="PyDMLabel" name="lbl">
+  <property name="geometry"><rect><x>0</x><y>0</y><width>80</width><height>20</height></rect></property>
+  <property name="text"><string>Px</string></property>
+  <property name="font"><font><family>Helvetica</family><pixelsize>15</pixelsize></font></property>
+ </widget>
+</widget></ui>"""
+    )
+    ir = ui_file_to_ir(ui)
+    assert ir.root.children[0].props["fontSize"] == 15
+
+
+def test_font_without_size_emits_nothing(tmp_path):
+    """A <font> with no point/pixel size must not add a bogus fontSize prop
+    (runtime default stands) and must never crash the conversion."""
+    from pydmconverter.ui.ir_adapter import ui_file_to_ir
+
+    ui = tmp_path / "nosize.ui"
+    ui.write_text(
+        """<?xml version="1.0"?>
+<ui version="4.0"><class>Form</class>
+<widget class="QWidget" name="centralwidget">
+ <property name="geometry"><rect><x>0</x><y>0</y><width>200</width><height>100</height></rect></property>
+ <widget class="PyDMLabel" name="lbl">
+  <property name="geometry"><rect><x>0</x><y>0</y><width>80</width><height>20</height></rect></property>
+  <property name="text"><string>NoSize</string></property>
+  <property name="font"><font><family>Helvetica</family><bold>true</bold></font></property>
+ </widget>
+</widget></ui>"""
+    )
+    ir = ui_file_to_ir(ui)
+    assert "fontSize" not in ir.root.children[0].props

--- a/tests/ui/test_template_repeater.py
+++ b/tests/ui/test_template_repeater.py
@@ -1,0 +1,123 @@
+"""PyDMTemplateRepeater -> N embedded-display materialization (.ui adapter).
+
+PyDM renders a template ``.ui`` once per record in a JSON dataSource, laid out
+horizontally/vertically. The adapter fans the repeater out into one
+embedded-display IR node per record (reusing the embedded-display path), each
+referencing the converted template screen and carrying the record as its macros.
+Missing/malformed dataSource falls back to the unknown-widget placeholder.
+"""
+
+import json
+from pathlib import Path
+
+from pydmconverter.ui.ir_adapter import ui_file_to_ir
+
+TEMPLATE_UI = """<?xml version="1.0"?>
+<ui version="4.0"><widget class="QWidget" name="Widget">
+  <property name="geometry"><rect><x>0</x><y>0</y><width>50</width><height>40</height></rect></property>
+</widget></ui>
+"""
+
+REPEATER_UI = """<?xml version="1.0"?>
+<ui version="4.0"><widget class="QWidget" name="screen">
+  <property name="geometry"><rect><x>0</x><y>0</y><width>500</width><height>300</height></rect></property>
+  <widget class="PyDMTemplateRepeater" name="rep">
+    <property name="geometry"><rect><x>10</x><y>20</y><width>400</width><height>40</height></rect></property>
+    <property name="layoutType" stdset="0"><enum>PyDMTemplateRepeater::Horizontal</enum></property>
+    <property name="layoutSpacing" stdset="0"><number>0</number></property>
+    <property name="countShownInDesigner" stdset="0"><number>10</number></property>
+    <property name="templateFilename" stdset="0"><string>{template}</string></property>
+    <property name="dataSource" stdset="0"><string>{data}</string></property>
+  </widget>
+</widget></ui>
+"""
+
+RECORDS = [
+    {"Name": "A", "Prefix": "DEV:A"},
+    {"Name": "B", "Prefix": "DEV:B"},
+    {"Name": "C", "Prefix": "DEV:C"},
+]
+
+
+def _write_screen(tmp_path: Path, *, template: str, data: str, records=RECORDS) -> Path:
+    (tmp_path / "Widget.ui").write_text(TEMPLATE_UI)
+    if records is not None:
+        (tmp_path / "data.json").write_text(json.dumps(records))
+    ui = tmp_path / "screen.ui"
+    ui.write_text(REPEATER_UI.format(template=template, data=data))
+    return ui
+
+
+def test_repeater_expands_to_embedded_displays(tmp_path):
+    ui = _write_screen(tmp_path, template="Widget.ui", data="data.json")
+    children = ui_file_to_ir(ui).root.children
+
+    embeds = [c for c in children if c.type == "embedded-display"]
+    assert len(embeds) == len(RECORDS)
+    assert all(c.type != "unknown-widget" for c in children)
+
+    # Each embed references the converted template screen and carries its record.
+    for embed, record in zip(embeds, RECORDS):
+        assert embed.props["file"] == "Widget.screen.json"
+        assert embed.props["macros"] == record
+
+    # Horizontal layout: stepped x by template width (50) + spacing (0); y constant.
+    xs = [c.geometry.x for c in embeds]
+    ys = [c.geometry.y for c in embeds]
+    assert xs == [10, 60, 110]
+    assert ys == [20, 20, 20]
+    # Instance geometry uses the template's footprint.
+    assert (embeds[0].geometry.width, embeds[0].geometry.height) == (50, 40)
+
+
+def test_repeater_vertical_and_spacing(tmp_path):
+    (tmp_path / "Widget.ui").write_text(TEMPLATE_UI)
+    (tmp_path / "data.json").write_text(json.dumps(RECORDS))
+    ui = tmp_path / "screen.ui"
+    ui.write_text(
+        """<?xml version="1.0"?>
+<ui version="4.0"><widget class="QWidget" name="screen">
+  <property name="geometry"><rect><x>0</x><y>0</y><width>500</width><height>300</height></rect></property>
+  <widget class="PyDMTemplateRepeater" name="rep">
+    <property name="geometry"><rect><x>10</x><y>20</y><width>60</width><height>200</height></rect></property>
+    <property name="layoutSpacing" stdset="0"><number>4</number></property>
+    <property name="templateFilename" stdset="0"><string>Widget.ui</string></property>
+    <property name="dataSource" stdset="0"><string>data.json</string></property>
+  </widget>
+</widget></ui>
+"""
+    )
+    embeds = [c for c in ui_file_to_ir(ui).root.children if c.type == "embedded-display"]
+    assert len(embeds) == 3
+    # layoutType absent -> Vertical (PyDM default): stepped y by height (40) + spacing (4).
+    assert [c.geometry.y for c in embeds] == [20, 64, 108]
+    assert [c.geometry.x for c in embeds] == [10, 10, 10]
+
+
+def test_missing_datasource_falls_back_to_unknown(tmp_path):
+    ui = _write_screen(tmp_path, template="Widget.ui", data="nope.json", records=None)
+    children = ui_file_to_ir(ui).root.children
+    assert [c.type for c in children] == ["unknown-widget"]
+    node = children[0]
+    assert node.props["originalClass"] == "PyDMTemplateRepeater"
+    assert any("missing/unreadable" in w for w in node.warnings)
+
+
+def test_malformed_datasource_falls_back_to_unknown(tmp_path):
+    (tmp_path / "Widget.ui").write_text(TEMPLATE_UI)
+    (tmp_path / "data.json").write_text("{not valid json")
+    ui = tmp_path / "screen.ui"
+    ui.write_text(REPEATER_UI.format(template="Widget.ui", data="data.json"))
+    children = ui_file_to_ir(ui).root.children
+    assert [c.type for c in children] == ["unknown-widget"]
+    assert any("missing/unreadable" in w for w in children[0].warnings)
+
+
+def test_datasource_not_a_list_falls_back(tmp_path):
+    (tmp_path / "Widget.ui").write_text(TEMPLATE_UI)
+    (tmp_path / "data.json").write_text(json.dumps({"Name": "A"}))  # object, not list
+    ui = tmp_path / "screen.ui"
+    ui.write_text(REPEATER_UI.format(template="Widget.ui", data="data.json"))
+    children = ui_file_to_ir(ui).root.children
+    assert [c.type for c in children] == ["unknown-widget"]
+    assert any("not a JSON list" in w for w in children[0].warnings)

--- a/tests/ui/test_unmapped_classes.py
+++ b/tests/ui/test_unmapped_classes.py
@@ -1,0 +1,190 @@
+"""Regression tests for the MC-batch unknown-widget reduction.
+
+Each previously-unmapped Qt/PyDM ``.ui`` class must now resolve to a concrete IR
+type (never ``unknown-widget``). Most go through the adapter's class-alias table
+(``_QT_CLASS_ALIASES``); ``PyDMSpinbox`` goes through a dedicated ``pv-spinbox``
+registry entry.
+"""
+
+from __future__ import annotations
+
+from pydmconverter.ui.ir_adapter import ui_file_to_ir
+
+
+def _one_widget_ui(inner: str) -> str:
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0"><widget class="QWidget" name="Form">
+ <property name="geometry"><rect><x>0</x><y>0</y><width>400</width><height>300</height></rect></property>
+ {inner}
+</widget></ui>"""
+
+
+def _first(ir):
+    return ir.root.children[0]
+
+
+def _convert(tmp_path, inner: str):
+    path = tmp_path / "w.ui"
+    path.write_text(_one_widget_ui(inner))
+    return ui_file_to_ir(path)
+
+
+def test_edm_display_button_maps_to_related_display_button(tmp_path):
+    inner = """<widget class="PyDMEDMDisplayButton" name="b">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>64</width><height>24</height></rect></property>
+      <property name="text"><string>IN20</string></property>
+      <property name="filenames" stdset="0"><stringlist><string>mc_in20</string></stringlist></property>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "related-display-button"
+    assert node.props["label"] == "IN20"
+    assert node.props["file"] == "mc_in20.screen.json"  # screenRef: extensionless target -> .screen.json
+
+
+def test_pydm_frame_maps_to_frame_container_with_children(tmp_path):
+    inner = """<widget class="PyDMFrame" name="fr">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>200</width><height>100</height></rect></property>
+      <widget class="QLabel" name="l">
+        <property name="geometry"><rect><x>5</x><y>5</y><width>50</width><height>20</height></rect></property>
+        <property name="text"><string>Inside</string></property>
+      </widget>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "frame"
+    assert [c.type for c in node.children] == ["text-label"]
+    assert node.children[0].props["text"] == "Inside"
+
+
+def test_qt_line_maps_to_line(tmp_path):
+    inner = """<widget class="Line" name="line">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>100</width><height>3</height></rect></property>
+      <property name="orientation"><enum>Qt::Horizontal</enum></property>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "line"
+
+
+def test_pydm_drawing_line_maps_to_line(tmp_path):
+    inner = """<widget class="PyDMDrawingLine" name="dl">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>100</width><height>3</height></rect></property>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "line"
+
+
+def test_pydm_spinbox_maps_to_pv_spinbox(tmp_path):
+    inner = """<widget class="PyDMSpinbox" name="sp">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>80</width><height>28</height></rect></property>
+      <property name="channel" stdset="0"><string>ca://${P}${M}.VAL</string></property>
+      <property name="showStepExponent" stdset="0"><bool>false</bool></property>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "pv-spinbox"
+    assert node.props["pv"] == "${P}${M}.VAL"  # ca:// stripped
+    assert node.props["showStepExponent"] is False
+
+
+def test_text_widgets_map_to_text_label(tmp_path):
+    for klass in ("QTextEdit", "QTextBrowser", "QLineEdit"):
+        inner = f"""<widget class="{klass}" name="t">
+          <property name="geometry"><rect><x>0</x><y>0</y><width>100</width><height>40</height></rect></property>
+        </widget>"""
+        node = _first(_convert(tmp_path, inner))
+        assert node.type == "text-label", klass
+
+
+def test_qlineedit_carries_its_text(tmp_path):
+    inner = """<widget class="QLineEdit" name="le">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>120</width><height>24</height></rect></property>
+      <property name="text"><string>Copper target controls</string></property>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "text-label"
+    assert node.props["text"] == "Copper target controls"
+
+
+def test_stacked_toolbox_pydmtab_map_to_tabs(tmp_path):
+    for klass in ("QStackedWidget", "QToolBox", "PyDMTabWidget"):
+        inner = f"""<widget class="{klass}" name="c">
+          <property name="geometry"><rect><x>0</x><y>0</y><width>200</width><height>150</height></rect></property>
+          <widget class="QLabel" name="l">
+            <property name="geometry"><rect><x>5</x><y>5</y><width>50</width><height>20</height></rect></property>
+            <property name="text"><string>Page</string></property>
+          </widget>
+        </widget>"""
+        node = _first(_convert(tmp_path, inner))
+        assert node.type == "tabs", klass
+        assert node.children[0].type == "text-label"  # children survive
+
+
+def test_pydm_drawing_pie_maps_to_arc(tmp_path):
+    inner = """<widget class="PyDMDrawingPie" name="pie">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>40</width><height>40</height></rect></property>
+      <property name="spanAngle"><double>180.0</double></property>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "arc"
+    assert node.props["spanAngle"] == 180.0
+
+
+def test_pydm_drawing_triangle_maps_to_polygon(tmp_path):
+    inner = """<widget class="PyDMDrawingTriangle" name="tri">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>20</width><height>20</height></rect></property>
+      <property name="rotation"><double>135.0</double></property>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "polygon"
+
+
+def test_pydm_drawing_circle_maps_to_ellipse(tmp_path):
+    inner = """<widget class="PyDMDrawingCircle" name="c">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>40</width><height>40</height></rect></property>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "ellipse"
+
+
+def test_pydm_time_plot_maps_to_waveform_plot(tmp_path):
+    inner = """<widget class="PyDMTimePlot" name="tp">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>200</width><height>120</height></rect></property>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "waveform-plot"
+
+
+def test_pydm_event_plot_maps_to_waveform_plot(tmp_path):
+    inner = """<widget class="PyDMEventPlot" name="ep">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>200</width><height>120</height></rect></property>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "waveform-plot"
+
+
+def test_qcombobox_maps_to_pv_enum_combobox(tmp_path):
+    inner = """<widget class="QComboBox" name="cb">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>120</width><height>28</height></rect></property>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "pv-enum-combobox"
+
+
+def test_qspinbox_maps_to_pv_spinbox(tmp_path):
+    inner = """<widget class="QSpinBox" name="sb">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>80</width><height>28</height></rect></property>
+      <property name="minimum"><number>0</number></property>
+      <property name="maximum"><number>100</number></property>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "pv-spinbox"
+
+
+def test_template_repeater_stays_unknown_placeholder(tmp_path):
+    """PyDMTemplateRepeater is not trivially mappable (external template + data
+    source, no inline children) — it remains an unknown-widget placeholder
+    (nothing disappears silently) and is flagged needs-human."""
+    inner = """<widget class="PyDMTemplateRepeater" name="tr">
+      <property name="geometry"><rect><x>0</x><y>0</y><width>100</width><height>100</height></rect></property>
+    </widget>"""
+    node = _first(_convert(tmp_path, inner))
+    assert node.type == "unknown-widget"
+    assert node.props["originalClass"] == "PyDMTemplateRepeater"


### PR DESCRIPTION
## Summary

Conversion-fidelity fixes for the `.ui` → Canopy Screen IR path, developed by
converting the full **mc-displays** screen set (449 `.ui` files, top-level +
subdirs) and comparing renders against PyDM. Brings converter output to **0
unknown-widgets** across the whole repo.

## What changed (by defect)

- **Static labels** — channel-less `PyDMLabel` kept its `text` (was blank).
- **Rules** — the PyDM `rules` JSON property is now parsed into IR visibility rules.
- **Font size** — source `<font><pointsize>` carried into a `fontSize` prop (px), so text renders at the intended size instead of the 13px default (no more `Curren…`/`PAU…` truncation).
- **Screen size** — `metadata.size` expands to encompass all children, so titles/edges past the root rect aren't clipped.
- **Label alignment** — Qt `alignment` mapped to `align` for centered section titles.
- **Lowercase macros** — `${dev}`/`${signal}` etc. are collected + validated (broadened the macro-name pattern to `^[A-Za-z]…`).
- **Widget mappings** — many previously-unmapped classes now resolve: polygon (PyDMDrawingIrregularPolygon/Triangle/Circle), PyDMEDMDisplayButton, PyDMFrame, Line/PyDMDrawingLine, QTextEdit/Browser/QLineEdit, PyDMSpinbox/QSpinBox, PyDMTimePlot/EventPlot→plot, QComboBox, tab/stack containers.
- **PyDMTemplateRepeater** — materialized into per-record `embedded-display` nodes (one per dataSource JSON record), laid out H/V.
- **Subscreen refs** — `screenRef` rewrites `foo.ui` → `foo.screen.json` **preserving the relative directory**, so subdir templates that share basenames (`Collimator/Widget` vs `Heater/Widget`) resolve correctly.

## Tests

`363 passed, 1 skipped` (full pytest suite). Regression tests added for each fix.

## Notes

- Registry JSONs edited here are mirrored in `Canopy/widget-registry-data` (see the companion PR there).
- A couple of `sol_motion_hl/*.ui` source files are malformed XML and fail to convert — flagged as source-repair `needs-human`, not a converter defect.
