### PR TITLE
Re-vendor screen-ir schema from @slaclab/canopy-screen-ir

### DIFF
--- a/pydmconverter/ir/data/VENDORED_SCHEMA.md
+++ b/pydmconverter/ir/data/VENDORED_SCHEMA.md
@@ -1,25 +1,26 @@
-# Vendored `@canopy/screen-ir` schema
+# Vendored `@slaclab/canopy-screen-ir` schema
 
 `screen-ir.schema.json` in this directory is **vendored**, not generated here.
-`@canopy/screen-ir` owns the Canopy screen contract; this converter is a
+`@slaclab/canopy-screen-ir` owns the Canopy screen contract; this converter is a
 disposable consumer that must produce IR the editor accepts. The converter
 validates its output against this file (`validate_screen_json`); it does not
 mint the contract.
 
 ## Pinned source
 
-- Package: `@canopy/screen-ir`
-- Version: `0.2.0` (`package.json` at the pinned commit)
-- Repo: `canopy-screen-builder`, branch `main` (PR #2 merged)
-- Commit: `affddbc` ("Add @canopy/screen-ir: the canonical, read-tolerant
-  screen IR" — step 1; on `main` via merge `a706d4a`)
-- Source path in that repo: `packages/screen-ir/schema/screen-ir.schema.json`
+- Package: `@slaclab/canopy-screen-ir` (the shared SDK contract package;
+  canopy-sdk-js issue #2). This is the single canonical home — the previous
+  `@canopy/screen-ir` copy in `canopy-screen-builder` and the workspace copy in
+  `canopy-screen-runtime` are being retired in favor of it.
+- Repo: `slaclab/canopy-sdk-js`, path `packages/screen-ir/schema/screen-ir.schema.json`
+- Release: `v0.1.1` (published; package version `0.1.0`)
+- Canonical macro-name pattern: `^[A-Za-z][A-Za-z0-9_]*$` (accepts lowercase —
+  PyDM/EDM sources author `${dev}`/`${signal}`).
 
 ## Re-vendoring
 
 Because this tool is short-lived there is no live sync. To refresh, copy the
-file from the pinned source path above and update the commit/version here, then
-run `python -m pytest tests/ir/test_ir_schema.py` to confirm converter output
-still validates. If validation fails, reconcile per
-`plans/converter-conformance-handoff.md`: fix converter output, or file a change
-against `@canopy/screen-ir` — do NOT widen only the converter's copy.
+file from the pinned source path above and update the source note here, then run
+`python -m pytest tests/ir/test_ir_schema.py` to confirm converter output still
+validates. If validation fails, reconcile: fix converter output, or file a
+change against `@slaclab/canopy-screen-ir` — do NOT widen only the converter's copy.

--- a/pydmconverter/ir/data/screen-ir.schema.json
+++ b/pydmconverter/ir/data/screen-ir.schema.json
@@ -54,7 +54,7 @@
       "additionalProperties": false,
       "required": ["name"],
       "properties": {
-        "name": { "type": "string", "pattern": "^[A-Z][A-Z0-9_]*$" },
+        "name": { "type": "string", "pattern": "^[A-Za-z][A-Za-z0-9_]*$" },
         "default": { "type": "string" },
         "description": { "type": "string" }
       }


### PR DESCRIPTION
## Summary

Re-vendor the Screen IR schema from the new canonical shared package
`@slaclab/canopy-screen-ir` (slaclab/canopy-sdk-js#3), replacing the older
`@canopy/screen-ir` vendor source. Part of canopy-sdk-js#2.

## What changed

- `pydmconverter/ir/data/screen-ir.schema.json` re-vendored from the SDK package (canonical macro pattern `^[A-Za-z]…`).
- `VENDORED_SCHEMA.md` repointed at `@slaclab/canopy-screen-ir`.

Converter schema tests pass (`tests/ir/test_ir_schema.py`; full suite 363).

---
**Stacked PR:** targets `fidelity/mc-batch` so the diff shows only the screen-ir migration. Merge the fidelity PR first (or rebase onto main after it lands).
