### PR TITLE
Conversion fidelity for the edm-batch screens: channel routing, alarm rules, symbols, pips, CALC plumbing

### DIFF
--- a/pydmconverter/__main__.py
+++ b/pydmconverter/__main__.py
@@ -41,7 +41,7 @@ def run(
     out_format="json",
 ):
     if target == "react":
-        run_react(input_file, output_file, override)
+        run_react(input_file, output_file, override, site=site, calc_list=calc_list)
         return
 
     input_path: Path = Path(input_file)
@@ -75,18 +75,20 @@ def run(
             print(f"Failed files: {', '.join(map(lambda path: str(path), files_failed))}")
 
 
-def run_react(input_file, output_file, override) -> None:
+def run_react(input_file, output_file, override, site=None, calc_list=None) -> None:
     """Convert .edl/.ui to Canopy Screen IR JSON (the --target react path)."""
     from pydmconverter import react
 
     input_path = Path(input_file)
     output_path = Path(output_file)
     if input_path.is_file():
-        out = react.convert_file(input_path, output_path, override=override)
+        out = react.convert_file(input_path, output_path, override=override, calc_list_path=calc_list, site=site)
         print(f"Converted {input_path} -> {out}")
     else:
         output_path.mkdir(parents=True, exist_ok=True)
-        found, failed = react.convert_folder(input_path, output_path, override=override)
+        found, failed = react.convert_folder(
+            input_path, output_path, override=override, calc_list_path=calc_list, site=site
+        )
         if found == 0:
             print(f"No {' or '.join(react.SUPPORTED_SUFFIXES)} files found in {input_path}")
         else:

--- a/pydmconverter/edm/edm_qt.py
+++ b/pydmconverter/edm/edm_qt.py
@@ -29,7 +29,9 @@ EDM_TO_QT_CLASS: dict[str, str] = {
     "activemotifsliderclass": "PyDMSlider",
     "activesliderclass": "PyDMSlider",
     "activetriumfsliderclass": "PyDMSlider",
-    "activechoicebuttonclass": "PyDMEnumComboBox",
+    # EDM choice button IS a radio set: every state visible, current one lit
+    # (a dropdown hides the alternatives and, closed, showed only the ordinal).
+    "activechoicebuttonclass": "PyDMEnumButton",
     "activepipclass": "PyDMEmbeddedDisplay",
     # byte indicator / related display
     "byteclass": "PyDMByteIndicator",
@@ -96,6 +98,13 @@ EDM_TO_QT_PROP: dict[str, str] = {
     "onLabel": "onLabel",
     "offLabel": "offLabel",
     "buttonType": "buttonType",
+    # state colors (buttons and byte indicators share the attr names)
+    "onColor": "onColor",
+    "offColor": "offColor",
+    # typography: EDM font strings ("helvetica-bold-r-12.0") -> pixel size.
+    # Without this every label rendered at the theme default and overflowed
+    # its EDM-sized box (ellipsis, or silently clipped digits).
+    "font": "fontSize",
     # slider
     "scaleMin": "userMinimum",
     "scaleMax": "userMaximum",

--- a/pydmconverter/edm/edm_qt.py
+++ b/pydmconverter/edm/edm_qt.py
@@ -34,6 +34,7 @@ EDM_TO_QT_CLASS: dict[str, str] = {
     # byte indicator / related display
     "byteclass": "PyDMByteIndicator",
     "relateddisplayclass": "PyDMRelatedDisplayButton",
+    "xygraphclass": "PyDMWaveformPlot",
     # graphics
     "activerectangleclass": "PyDMDrawingRectangle",
     "activecircleclass": "PyDMDrawingEllipse",

--- a/pydmconverter/edm/edm_qt.py
+++ b/pydmconverter/edm/edm_qt.py
@@ -59,20 +59,24 @@ EDM_TO_QT_CLASS: dict[str, str] = {
     # menuMuxClass deliberately absent: macro-muxing needs a design; stays unknown-widget.
 }
 
-# EDM attributes that name a PV channel.
-EDM_CHANNEL_ATTRS = ("controlPv", "indicatorPv", "readPv", "alarmPv", "pv", "filePv", "nullPv", "ctrl1Pv")
+# EDM attributes that name a data-PV channel, in PRIMARY-channel priority order.
+# When an object carries several (EDM buttons pair controlPv with indicatorPv),
+# controlPv wins: it is the write/primary channel; readPv/indicatorPv are
+# readbacks; the rest only ever appear alone. The adapter picks primary +
+# readback explicitly (ir_adapter._apply_channel_attrs) — funneling them all to
+# the single "channel" prop kept only the last attr parsed and re-pointed
+# widgets at the wrong PV.
+EDM_PRIMARY_CHANNEL_ORDER = ("controlPv", "readPv", "indicatorPv", "pv", "filePv", "nullPv", "ctrl1Pv")
+# Readback preference when a second data channel is present.
+EDM_READBACK_CHANNEL_ORDER = ("indicatorPv", "readPv")
+# alarmPv is deliberately NOT a data channel: it names the alarm-severity source
+# for alarm-color rules (ir_adapter._alarm_rules) and must never steal the
+# widget's channel (nor make a static label "live" — see has_pv).
+EDM_CHANNEL_ATTRS = EDM_PRIMARY_CHANNEL_ORDER + ("alarmPv",)
 
 # EDM attribute name -> Qt prop name (the key Beaver's qtPropMap consumes).
+# Channel attrs are absent on purpose: the adapter routes them itself.
 EDM_TO_QT_PROP: dict[str, str] = {
-    # channels (all funnel to "channel"; Beaver maps channel -> pv via stripProtocol)
-    "controlPv": "channel",
-    "indicatorPv": "channel",
-    "readPv": "channel",
-    "alarmPv": "channel",
-    "pv": "channel",
-    "filePv": "channel",
-    "nullPv": "channel",
-    "ctrl1Pv": "channel",  # mmvClass
     # text / labels (Beaver maps "text" -> text/label per widget)
     "value": "text",
     "label": "text",
@@ -86,9 +90,12 @@ EDM_TO_QT_PROP: dict[str, str] = {
     "fgAlarm": "alarmSensitiveContent",
     "alarmSensitiveContent": "alarmSensitiveContent",
     "alarmSensitiveBorder": "alarmSensitiveBorder",
-    # button values
+    # button values / state labels / behavior
     "pressValue": "pressValue",
     "releaseValue": "releaseValue",
+    "onLabel": "onLabel",
+    "offLabel": "offLabel",
+    "buttonType": "buttonType",
     # slider
     "scaleMin": "userMinimum",
     "scaleMax": "userMaximum",
@@ -127,8 +134,13 @@ EDM_TO_QT_PROP: dict[str, str] = {
 
 
 def has_pv(properties: dict[str, Any]) -> bool:
-    """True if the EDM object carries any PV channel attribute."""
-    return any(attr in properties for attr in EDM_CHANNEL_ATTRS)
+    """True if the EDM object carries a DATA channel attribute.
+
+    alarmPv does not count: it only feeds alarm-color rules, so e.g. a static
+    label with an alarmPv stays a static label (previously it converted to a
+    live pv-label bound to the alarm PV and displayed that PV's value).
+    """
+    return any(attr in properties for attr in EDM_PRIMARY_CHANNEL_ORDER)
 
 
 def resolve_qt_class(name_lower: str, properties: dict[str, Any]) -> str | None:
@@ -137,7 +149,13 @@ def resolve_qt_class(name_lower: str, properties: dict[str, Any]) -> str | None:
     A static ``activeXTextClass`` (no PV) is a label with fixed text, so it maps to
     ``QLabel`` (-> ``text-label``, which has a ``text`` prop). With a PV it is a live
     value display, so it maps to ``PyDMLabel`` (-> ``pv-label``).
+
+    A closed or filled ``activeLineClass`` is a polygon, not a polyline — the
+    polyline widget has no fill, so EDM's filled shapes (triangles, flow arrows)
+    rendered as empty outlines.
     """
     if name_lower == "activextextclass" and not has_pv(properties):
         return "QLabel"
+    if name_lower == "activelineclass" and (properties.get("fill") or properties.get("closePolygon")):
+        return "PyDMDrawingIrregularPolygon"
     return EDM_TO_QT_CLASS.get(name_lower)

--- a/pydmconverter/edm/ir_adapter.py
+++ b/pydmconverter/edm/ir_adapter.py
@@ -22,6 +22,7 @@ unknown-widget.
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 from typing import Any, Callable
@@ -382,6 +383,46 @@ def _fixup_multiline_text_entry(obj: EDMObject, qt_props: dict[str, Any], warnin
     return None
 
 
+def _fixup_state_button(obj: EDMObject, qt_props: dict[str, Any], warnings: list[str]) -> Geometry | None:
+    """activeMessageButtonClass/activeButtonClass fixup: EDM buttons label via
+    onLabel/offLabel (buttonLabel is rare on these classes); the visible resting
+    label is offLabel. Distinct on/off labels are press-state behavior the web
+    button doesn't model — keep the resting label and say so.
+    """
+    if not qt_props.get("text"):
+        off_label = obj.properties.get("offLabel")
+        on_label = obj.properties.get("onLabel")
+        label = off_label or on_label
+        if label:
+            qt_props["text"] = normalize_macro_syntax(str(label))
+    on_label = obj.properties.get("onLabel")
+    off_label = obj.properties.get("offLabel")
+    if on_label and off_label and on_label != off_label:
+        warnings.append("EDM on/off button labels differ; resting (off) label kept")
+    return None
+
+
+def _fixup_xy_graph(obj: EDMObject, qt_props: dict[str, Any], warnings: list[str]) -> Geometry | None:
+    """xyGraphClass fixup: EDM trace lists -> the registry's PyDM-style curves.
+
+    Each EDM yPv becomes one curve JSON string ({"y_channel": ...}); the registry
+    transform parses them. x channels have no time-series analog and are noted.
+    """
+    y_pvs = [pv for pv in _as_str_list(obj.properties.get("yPv")) if pv]
+    curves = [
+        json.dumps({"y_channel": normalize_macro_syntax(pv), "name": f"trace {index + 1}"})
+        for index, pv in enumerate(y_pvs)
+    ]
+    if curves:
+        qt_props["curves"] = curves
+    title = obj.properties.get("graphTitle")
+    if title:
+        qt_props["title"] = normalize_macro_syntax(str(title))
+    if obj.properties.get("xPv"):
+        warnings.append("EDM xyGraph x-channel dropped (rendered as time-series)")
+    return None
+
+
 def _fixup_meter(obj: EDMObject, qt_props: dict[str, Any], warnings: list[str]) -> Geometry | None:
     """activeMeterClass fixup: warn when labelType isn't the literal-text default.
 
@@ -413,6 +454,9 @@ _CLASS_FIXUPS.update(
         "multilinetextentryclass": _fixup_multiline_text_entry,
         "activemeterclass": _fixup_meter,
         "activeindicatorclass": _fixup_bar,
+        "activemessagebuttonclass": _fixup_state_button,
+        "activebuttonclass": _fixup_state_button,
+        "xygraphclass": _fixup_xy_graph,
         # activepngclass, activeradiobuttonclass: no fixup needed; global renames suffice.
     }
 )
@@ -561,10 +605,18 @@ def edm_file_to_ir(
     colors = parse_colors_list(colors_path)
     top_level = edm_group_to_source_nodes(parser.ui, colors=colors)
     builder = IRBuilder(registry or VendoredRegistry())
+    # Screen background: the parser resolves bgColor to an (r, g, b, a) tuple.
+    background: str | None = None
+    bg = getattr(parser.ui, "properties", {}).get("bgColor") if getattr(parser.ui, "properties", None) else None
+    if hasattr(bg, "r") and hasattr(bg, "g") and hasattr(bg, "b"):
+        background = "#{:02x}{:02x}{:02x}".format(int(bg.r), int(bg.g), int(bg.b))
+    elif isinstance(bg, (tuple, list)) and len(bg) >= 3:
+        background = "#{:02x}{:02x}{:02x}".format(int(bg[0]), int(bg[1]), int(bg[2]))
     return builder.build_screen(
         screen_id=path.stem,
         title=path.stem,
         source_type="edl-converter",
         size=(parser.ui.width, parser.ui.height),
         top_level=top_level,
+        background=background,
     )

--- a/pydmconverter/edm/ir_adapter.py
+++ b/pydmconverter/edm/ir_adapter.py
@@ -27,7 +27,12 @@ import re
 from pathlib import Path
 from typing import Any, Callable
 
-from pydmconverter.edm.edm_qt import EDM_TO_QT_PROP, resolve_qt_class
+from pydmconverter.edm.edm_qt import (
+    EDM_PRIMARY_CHANNEL_ORDER,
+    EDM_READBACK_CHANNEL_ORDER,
+    EDM_TO_QT_PROP,
+    resolve_qt_class,
+)
 from pydmconverter.edm.parser import EDMFileParser, EDMGroup, EDMObject
 from pydmconverter.edm.parser_helpers import (
     get_color_by_index,
@@ -41,6 +46,7 @@ from pydmconverter.ir.macros import normalize_macro_syntax
 from pydmconverter.ir.model import Number, ScreenIR
 from pydmconverter.ir.registry import RegistryClient, VendoredRegistry
 from pydmconverter.ir.source import RuleSpec, SourceNode
+from pydmconverter.ir.transforms import screen_ref
 
 # An EDM visibility spec: (visPv, visMin, visMax, visInvert). visMin/visMax are
 # None when the EDM object only declares visPv (visible-when-nonzero).
@@ -184,6 +190,107 @@ def edm_color_to_hex(value: Any, color_data: dict[str, Any] | None) -> str | Non
     return f"#{red:02x}{green:02x}{blue:02x}"
 
 
+# Classes whose registry definition maps a readback channel (readbackChannel ->
+# pv-button's readbackPV). Elsewhere a second data channel has nowhere to land
+# and is dropped with a warning.
+_READBACK_CLASSES = {"activebuttonclass", "activemessagebuttonclass"}
+
+# EDM alarm-severity palette (green / yellow / red / white-invalid) — what an
+# alarm-sensitive EDM part shows instead of its configured static color.
+_ALARM_RULE_CONDITIONS: list[tuple[str, str]] = [
+    ("{0} == 1", "#ffff00"),
+    ("{0} == 2", "#ff0000"),
+    ("{0} >= 3", "#ffffff"),
+]
+_ALARM_RULE_DEFAULT = "#00c000"
+
+# alarm flag -> IR target prop, per class family. Targets are IR prop names
+# (RuleSpecs pass through the builder untranslated).
+_DRAWING_ALARM_TARGETS = (("lineAlarm", "lineColor"), ("fillAlarm", "fillColor"))
+_LABEL_ALARM_TARGETS = (("fgAlarm", "foregroundColor"), ("bgAlarm", "backgroundColor"))
+_DRAWING_CLASSES = {"activerectangleclass", "activecircleclass", "activelineclass", "activearcclass"}
+_LABEL_ALARM_CLASSES = {
+    "activextextclass",
+    "textupdateclass",
+    "multilinetextupdateclass",
+    "activexregtextclass",
+    "regtextupdateclass",
+    "activextextdspclassnoedit",
+}
+
+# A trailing EPICS field ref (".RBV", ".PLOK") — severity is record-level, so it
+# is stripped before appending .SEVR.
+_FIELD_SUFFIX_RE = re.compile(r"\.[A-Z][A-Z0-9]*$")
+
+
+def _severity_channel(pv: str) -> str:
+    """The CA channel carrying the alarm severity of ``pv``'s record."""
+    if pv.endswith(".SEVR"):
+        return pv
+    return _FIELD_SUFFIX_RE.sub("", pv) + ".SEVR"
+
+
+def _alarm_rules(obj: EDMObject) -> list[RuleSpec]:
+    """EDM alarmPv + alarm flags -> alarm-color RuleSpecs (EDM severity palette).
+
+    EDM semantics: an alarm-sensitive part tracks the alarm severity of
+    ``alarmPv`` (green when NO_ALARM — the static color only shows while
+    disconnected). Flags select what tracks: lineAlarm/fillAlarm on drawing
+    classes, fgAlarm/bgAlarm on label classes. alarmPv without any flag (or a
+    flag without alarmPv) does nothing, matching EDM.
+    """
+    alarm_pv = obj.properties.get("alarmPv")
+    if isinstance(alarm_pv, list):
+        alarm_pv = alarm_pv[0] if alarm_pv else ""
+    if not alarm_pv:
+        return []
+    alarm_pv = normalize_macro_syntax(str(alarm_pv))
+    name_lower = obj.name.lower()
+    if name_lower in _DRAWING_CLASSES:
+        targets = _DRAWING_ALARM_TARGETS
+    elif name_lower in _LABEL_ALARM_CLASSES:
+        targets = _LABEL_ALARM_TARGETS
+    else:
+        return []
+    rules: list[RuleSpec] = []
+    for flag, target in targets:
+        if obj.properties.get(flag):
+            rules.append(
+                RuleSpec(
+                    target_property=target,
+                    name=f"Alarm color ({target})",
+                    pvs=[(_severity_channel(alarm_pv), True)],
+                    conditions=list(_ALARM_RULE_CONDITIONS),
+                    default=_ALARM_RULE_DEFAULT,
+                )
+            )
+    return rules
+
+
+def _apply_channel_attrs(obj: EDMObject, qt_props: dict[str, Any], warnings: list[str]) -> None:
+    """Route the object's data-channel attrs: primary -> ``channel``, readback ->
+    ``readbackChannel`` (registry maps it only where a readback exists, i.e.
+    pv-button). Anything else is dropped loudly — silently keeping the last
+    attr parsed is how buttons ended up writing to their readback PV.
+    """
+    primary = next((attr for attr in EDM_PRIMARY_CHANNEL_ORDER if obj.properties.get(attr)), None)
+    if primary is None:
+        return
+    qt_props["channel"] = _to_channel(obj.properties[primary])
+    readback = next(
+        (attr for attr in EDM_READBACK_CHANNEL_ORDER if attr != primary and obj.properties.get(attr)),
+        None,
+    )
+    if readback is not None:
+        if obj.name.lower() in _READBACK_CLASSES:
+            qt_props["readbackChannel"] = _to_channel(obj.properties[readback])
+        else:
+            warnings.append(f"EDM {readback} readback dropped ({primary} kept as the channel)")
+    for attr in EDM_PRIMARY_CHANNEL_ORDER:
+        if attr not in (primary, readback) and obj.properties.get(attr):
+            warnings.append(f"EDM {attr} dropped ({primary} kept as the channel)")
+
+
 # Per-class fixup: keyed by lowercased EDM class name. Runs after the generic
 # prop loop (and color/dynamic-flag handling) in ``_object_to_source``. May
 # mutate ``qt_props``/``warnings`` in place and may return a geometry override
@@ -205,9 +312,11 @@ def _apply_shared_drawing_fixup(obj: EDMObject, qt_props: dict[str, Any], warnin
         # X11 width-0 means thinnest visible line; width 0 in the builder renders nothing.
         qt_props["penWidth"] = 1
     alarm_flags = [flag for flag in ("lineAlarm", "fillAlarm") if obj.properties.get(flag)]
-    if alarm_flags:
+    if alarm_flags and not obj.properties.get("alarmPv"):
+        # With an alarmPv these flags become alarm-color rules (_alarm_rules);
+        # without one EDM ignores them, but say so rather than vanish them.
         flags = ", ".join(alarm_flags)
-        warnings.append(f"EDM alarm-driven colors ({flags}) are not supported; static colors emitted")
+        warnings.append(f"EDM alarm flags ({flags}) without alarmPv; static colors emitted")
 
 
 def _parse_line_points(obj: EDMObject) -> list[tuple[float, float]] | None:
@@ -225,7 +334,12 @@ def _parse_line_points(obj: EDMObject) -> list[tuple[float, float]] | None:
 
 
 def _fixup_line(obj: EDMObject, qt_props: dict[str, Any], warnings: list[str]) -> Geometry | None:
-    """activeLineClass fixup: shared drawing logic + points/arrows/fill handling."""
+    """activeLineClass fixup: shared drawing logic + points/arrows/fill handling.
+
+    A closed or filled line resolves to the polygon widget (resolve_qt_class),
+    which consumes the same points plus brushFill/brushColor and a ``closed``
+    flag; an open line stays a polyline (no fill props).
+    """
     _apply_shared_drawing_fixup(obj, qt_props, warnings)
 
     geometry_override: Geometry | None = None
@@ -246,11 +360,7 @@ def _fixup_line(obj: EDMObject, qt_props: dict[str, Any], warnings: list[str]) -
     qt_props["arrowEndPoint"] = arrows in ("to", "both")
 
     if obj.properties.get("fill") or obj.properties.get("closePolygon"):
-        # Line has no fill; brushFill arrives via the global fill->brushFill
-        # rename and the line def would drop it anyway, but pop for cleanliness.
-        qt_props.pop("brushFill", None)
-        qt_props.pop("brushColor", None)
-        warnings.append("EDM filled/closed polygon is rendered as an open polyline")
+        qt_props["closePolygon"] = True
 
     return geometry_override
 
@@ -386,19 +496,22 @@ def _fixup_multiline_text_entry(obj: EDMObject, qt_props: dict[str, Any], warnin
 def _fixup_state_button(obj: EDMObject, qt_props: dict[str, Any], warnings: list[str]) -> Geometry | None:
     """activeMessageButtonClass/activeButtonClass fixup: EDM buttons label via
     onLabel/offLabel (buttonLabel is rare on these classes); the visible resting
-    label is offLabel. Distinct on/off labels are press-state behavior the web
-    button doesn't model — keep the resting label and say so.
+    label is offLabel. With a readback channel the web button switches
+    onLabel/offLabel live (isOn from readbackPV); without one distinct labels
+    cannot switch — keep the resting label and say so.
     """
+    off_label = obj.properties.get("offLabel")
+    on_label = obj.properties.get("onLabel")
     if not qt_props.get("text"):
-        off_label = obj.properties.get("offLabel")
-        on_label = obj.properties.get("onLabel")
         label = off_label or on_label
         if label:
             qt_props["text"] = normalize_macro_syntax(str(label))
-    on_label = obj.properties.get("onLabel")
-    off_label = obj.properties.get("offLabel")
-    if on_label and off_label and on_label != off_label:
-        warnings.append("EDM on/off button labels differ; resting (off) label kept")
+    if obj.name.lower() == "activebuttonclass":
+        # EDM's Button is a toggle unless buttonType says otherwise; the web
+        # button defaults to momentary push, so the default must be written.
+        qt_props.setdefault("buttonType", "toggle")
+    if on_label and off_label and on_label != off_label and "readbackChannel" not in qt_props:
+        warnings.append("EDM on/off button labels differ; resting (off) label kept (no readback channel)")
     return None
 
 
@@ -406,21 +519,91 @@ def _fixup_xy_graph(obj: EDMObject, qt_props: dict[str, Any], warnings: list[str
     """xyGraphClass fixup: EDM trace lists -> the registry's PyDM-style curves.
 
     Each EDM yPv becomes one curve JSON string ({"y_channel": ...}); the registry
-    transform parses them. x channels have no time-series analog and are noted.
+    transform parses them. A parallel xPv entry rides along as ``x_channel``
+    (waveform-vs-waveform traces; the plot renders time-series when absent).
     """
     y_pvs = [pv for pv in _as_str_list(obj.properties.get("yPv")) if pv]
-    curves = [
-        json.dumps({"y_channel": normalize_macro_syntax(pv), "name": f"trace {index + 1}"})
-        for index, pv in enumerate(y_pvs)
-    ]
+    x_pvs = _as_str_list(obj.properties.get("xPv"))
+    curves = []
+    for index, pv in enumerate(y_pvs):
+        curve: dict[str, Any] = {"y_channel": normalize_macro_syntax(pv), "name": f"trace {index + 1}"}
+        if index < len(x_pvs) and x_pvs[index]:
+            curve["x_channel"] = normalize_macro_syntax(x_pvs[index])
+        curves.append(json.dumps(curve))
     if curves:
         qt_props["curves"] = curves
     title = obj.properties.get("graphTitle")
     if title:
         qt_props["title"] = normalize_macro_syntax(str(title))
-    if obj.properties.get("xPv"):
-        warnings.append("EDM xyGraph x-channel dropped (rendered as time-series)")
     return None
+
+
+def _pip_menu_refs(obj: EDMObject) -> list[str]:
+    """displaySource=menu pip: the ``displayFileName`` entries as screen refs
+    (same normalization the ``screenRef`` transform applies — rule values bypass
+    ``qtPropMap`` transforms, so the adapter must pre-normalize)."""
+    refs: list[str] = []
+    for name in _as_str_list(obj.properties.get("displayFileName")):
+        normalized = normalize_macro_syntax(name)
+        ref = screen_ref(normalized)
+        if isinstance(ref, str) and ref.strip():
+            refs.append(ref)
+    return refs
+
+
+def _fixup_pip(obj: EDMObject, qt_props: dict[str, Any], warnings: list[str]) -> Geometry | None:
+    """activePipClass fixup by displaySource:
+
+    - "file" (default): the macro-bearing ``file`` template is already mapped
+      (file -> filename -> screenRef keeps ``${VAR}`` refs for view-time
+      resolution) — nothing to do.
+    - "menu": ``filePv`` selects among ``displayFileName`` entries; emit the
+      first entry as the static file and let ``_pip_rules`` switch it live.
+    - "stringPv": the file name is the PV's string value; no rule-conditions
+      analog, surfaced as a warning instead of dropping the node silently.
+    """
+    source = str(obj.properties.get("displaySource", "file") or "file").strip().lower()
+    if source in ("", "file"):
+        return None
+    if source == "menu":
+        names = _as_str_list(obj.properties.get("displayFileName"))
+        if names and obj.properties.get("filePv"):
+            # Raw first entry: the builder's screenRef transform normalizes it.
+            qt_props["filename"] = normalize_macro_syntax(names[0])
+            if len(_as_str_list(obj.properties.get("symbols"))) > 1:
+                warnings.append("EDM menu pip per-entry symbols are merged; macros do not switch with the file")
+        else:
+            warnings.append("EDM menu pip without filePv/displayFileName; no file emitted")
+    elif source == "stringpv":
+        warnings.append("EDM stringPv-driven embedded file is not translated; no file emitted")
+    else:
+        warnings.append(f"EDM pip displaySource '{source}' is not translated; no file emitted")
+    return None
+
+
+def _pip_rules(obj: EDMObject) -> list[RuleSpec]:
+    """displaySource=menu pip -> a ``file`` rule keyed on the filePv's value."""
+    if obj.name.lower() != "activepipclass":
+        return []
+    source = str(obj.properties.get("displaySource", "file") or "file").strip().lower()
+    file_pv = obj.properties.get("filePv")
+    if source != "menu" or not file_pv:
+        return []
+    refs = _pip_menu_refs(obj)
+    if not refs:
+        return []
+    if isinstance(file_pv, list):
+        file_pv = file_pv[0] if file_pv else ""
+    file_pv = normalize_macro_syntax(str(file_pv))
+    return [
+        RuleSpec(
+            target_property="file",
+            name="Embedded file (menu)",
+            pvs=[(file_pv, True)],
+            conditions=[(f"{{0}} == {index}", ref) for index, ref in enumerate(refs)],
+            default=refs[0],
+        )
+    ]
 
 
 def _fixup_meter(obj: EDMObject, qt_props: dict[str, Any], warnings: list[str]) -> Geometry | None:
@@ -457,6 +640,7 @@ _CLASS_FIXUPS.update(
         "activemessagebuttonclass": _fixup_state_button,
         "activebuttonclass": _fixup_state_button,
         "xygraphclass": _fixup_xy_graph,
+        "activepipclass": _fixup_pip,
         # activepngclass, activeradiobuttonclass: no fixup needed; global renames suffice.
     }
 )
@@ -466,6 +650,7 @@ def _object_to_source(obj: EDMObject, colors: dict[str, Any] | None = None) -> S
     qt_class = resolve_qt_class(obj.name.lower(), obj.properties)
     qt_props: dict[str, Any] = {}
     warnings: list[str] = []
+    rules: list[RuleSpec] = []
     geometry: Geometry = (obj.x, obj.y, obj.width, obj.height)
     if qt_class is not None:
         use_display_bg = bool(obj.properties.get("useDisplayBg"))
@@ -485,9 +670,16 @@ def _object_to_source(obj: EDMObject, colors: dict[str, Any] | None = None) -> S
                 qt_props[qt_prop] = hex_color
                 continue
             qt_props[qt_prop] = _coerce(qt_prop, value)
-        for flag in ("colorPv", "bgAlarm"):
-            if obj.properties.get(flag):
-                warnings.append(f"EDM dynamic color ({flag}) is not supported; static colors emitted")
+        _apply_channel_attrs(obj, qt_props, warnings)
+        rules = _alarm_rules(obj) + _pip_rules(obj)
+        if any(rule.target_property == "foregroundColor" for rule in rules):
+            # The alarm rule replaces own-PV alarm sensitivity (EDM: alarmPv
+            # overrides the widget's own channel as the alarm source).
+            qt_props.pop("alarmSensitiveContent", None)
+        if obj.properties.get("colorPv"):
+            warnings.append("EDM dynamic color (colorPv) is not supported; static colors emitted")
+        if obj.properties.get("bgAlarm") and not any(rule.target_property == "backgroundColor" for rule in rules):
+            warnings.append("EDM dynamic color (bgAlarm) is not supported; static colors emitted")
         fixup = _CLASS_FIXUPS.get(obj.name.lower())
         if fixup is not None:
             override = fixup(obj, qt_props, warnings)
@@ -497,10 +689,40 @@ def _object_to_source(obj: EDMObject, colors: dict[str, Any] | None = None) -> S
         qt_class=qt_class,
         qt_props=qt_props,
         geometry=geometry,
+        rules=rules,
         raw_class=obj.name,
         raw_props=dict(obj.properties),
         warnings=warnings,
     )
+
+
+def _symbol_state_vis(group: EDMGroup) -> VisTuple | None:
+    """Per-state visibility for an exploded activeSymbolClass state group.
+
+    The parser explodes a symbol into one child EDMGroup per state, stamping the
+    state range (``symbolMin``/``symbolMax``) on the group and the symbol channel
+    (``symbolChannel``) on its leaf objects. Without a rule every state renders
+    stacked; with one, exactly the state whose range holds the channel's value
+    shows — EDM symbol semantics (min <= value < max).
+    """
+    props = getattr(group, "properties", None) or {}
+    if "symbolMin" not in props or "symbolMax" not in props:
+        return None
+    channel = None
+    for sub_object in group.objects:
+        sub_props = getattr(sub_object, "properties", None) or {}
+        if sub_props.get("symbolChannel"):
+            channel = sub_props["symbolChannel"]
+            break
+    if not channel:
+        return None
+    try:
+        vis_min = float(props["symbolMin"])
+        vis_max = float(props["symbolMax"])
+    except (TypeError, ValueError):
+        return None
+    channel = normalize_macro_syntax(_strip_leading_index(str(channel)))
+    return (channel, vis_min, vis_max, False)
 
 
 def _vis_tuple(properties: dict[str, Any]) -> VisTuple | None:
@@ -548,7 +770,9 @@ def _visibility_rule_spec(vis_tuples: list[VisTuple]) -> RuleSpec:
     )
 
 
-def edm_group_to_source_nodes(group: EDMGroup, *, colors: dict[str, Any] | None = None) -> list[SourceNode]:
+def edm_group_to_source_nodes(
+    group: EDMGroup, *, colors: dict[str, Any] | None = None, skip_classes: frozenset[str] = frozenset()
+) -> list[SourceNode]:
     """Materialize an EDM group tree into a list of widget SourceNodes.
 
     EDM groups are materialized as ``group`` widget nodes (the registry's ``group``
@@ -572,23 +796,37 @@ def edm_group_to_source_nodes(group: EDMGroup, *, colors: dict[str, Any] | None 
                 geometry=(obj.x, obj.y, obj.width, obj.height),
                 raw_class="activeGroupClass",
                 raw_props=dict(obj.properties),
-                children=edm_group_to_source_nodes(obj, colors=colors),
+                children=edm_group_to_source_nodes(obj, colors=colors, skip_classes=skip_classes),
             )
+            vis_tuples: list[VisTuple] = []
+            symbol_vis = _symbol_state_vis(obj)
+            if symbol_vis is not None:
+                vis_tuples.append(symbol_vis)
             group_vis = _vis_tuple(obj.properties)
             if group_vis is not None:
-                group_node.rules = [_visibility_rule_spec([group_vis])]
+                vis_tuples.append(group_vis)
+            if vis_tuples:
+                group_node.rules = [_visibility_rule_spec(vis_tuples)]
             nodes.append(group_node)
         elif isinstance(obj, EDMObject):
+            if obj.name.lower() in skip_classes:
+                continue
             node = _object_to_source(obj, colors)
             own_vis = _vis_tuple(obj.properties)
             if own_vis is not None:
-                node.rules = [_visibility_rule_spec([own_vis])]
+                # Append: the node may already carry alarm-color rules.
+                node.rules.append(_visibility_rule_spec([own_vis]))
             nodes.append(node)
     return nodes
 
 
 def edm_file_to_ir(
-    input_path: str | Path, *, registry: RegistryClient | None = None, color_list_path: str | Path | None = None
+    input_path: str | Path,
+    *,
+    registry: RegistryClient | None = None,
+    color_list_path: str | Path | None = None,
+    calc_list_path: str | Path | None = None,
+    site: str | None = None,
 ) -> ScreenIR:
     """Parse an ``.edl`` file and build its Screen IR.
 
@@ -598,12 +836,26 @@ def edm_file_to_ir(
     an explicit ``color_list_path`` wins over all of those. If no palette is found,
     "index N" colors cannot be resolved and are dropped with a node warning ("rgb ..."
     colors resolve without a palette).
+
+    ``calc_list_path`` points at an EDM ``calc.list`` used to resolve named
+    ``CALC\\`` PVs; when omitted the parser searches beside the input file, then
+    ``$EDMFILES/calc.list``, then beside ``$EDMCOLORFILE``. Unresolvable named
+    calcs stay as warnings. ``site`` applies site skip rules (same vocabulary as
+    the PyDM target, e.g. ``"slac"`` drops exit buttons).
     """
+    from pydmconverter.sites import get_skip_widgets
+
     path = Path(input_path)
-    parser = EDMFileParser(str(path), str(path.with_suffix(".ui")))
+    parser = EDMFileParser(
+        str(path),
+        str(path.with_suffix(".ui")),
+        calc_list_file=str(calc_list_path) if calc_list_path else None,
+        calc_reuse_short=False,
+    )
     colors_path = search_color_list(str(color_list_path) if color_list_path else None)
     colors = parse_colors_list(colors_path)
-    top_level = edm_group_to_source_nodes(parser.ui, colors=colors)
+    skip_classes = frozenset(get_skip_widgets(site))
+    top_level = edm_group_to_source_nodes(parser.ui, colors=colors, skip_classes=skip_classes)
     builder = IRBuilder(registry or VendoredRegistry())
     # Screen background: the parser resolves bgColor to an (r, g, b, a) tuple.
     background: str | None = None

--- a/pydmconverter/edm/ir_adapter.py
+++ b/pydmconverter/edm/ir_adapter.py
@@ -67,7 +67,9 @@ _BOOL_PROPS = {"showUnits", "alarmSensitiveContent", "alarmSensitiveBorder", "sh
 # Qt props holding an EDM color value ("index N" / "rgb r g b") that must be
 # resolved to "#rrggbb" hex before the builder sees them. penColor/brushColor are
 # consumed by the drawing widget defs (rectangle/ellipse/line/arc).
-_COLOR_PROPS = {"penColor", "brushColor", "foregroundColor", "backgroundColor"}
+_COLOR_PROPS = {"penColor", "brushColor", "foregroundColor", "backgroundColor", "onColor", "offColor"}
+# EDM font string "family-weight-slant-size" -> pixel size for the IR fontSize.
+_FONT_PROPS = {"fontSize"}
 # displayFormat carries pv-label's "format" enum value; EDM's format strings must
 # be normalized to the registry's vocabulary (decimal/hex/string/exponential/default).
 _FORMAT_PROPS = {"displayFormat"}
@@ -129,6 +131,22 @@ def _to_format(value: Any) -> str:
     return "default"
 
 
+def _to_font_size(value: Any) -> Any:
+    """EDM font string ("helvetica-bold-r-12.0") -> integer pixel size.
+
+    EDM bitmap-font sizes render ~1:1 as CSS pixels. Malformed values drop the
+    prop (returning None) rather than guessing a size.
+    """
+    if not isinstance(value, str):
+        return None
+    tail = value.rsplit("-", 1)[-1]
+    try:
+        size = float(tail)
+    except ValueError:
+        return None
+    return max(6, round(size)) if size > 0 else None
+
+
 def _coerce(qt_prop: str, value: Any) -> Any:
     if qt_prop in _CHANNEL_PROPS:
         return _to_channel(value)
@@ -142,6 +160,8 @@ def _coerce(qt_prop: str, value: Any) -> Any:
         return _to_bool(value)
     if qt_prop in _FORMAT_PROPS:
         return _to_format(value)
+    if qt_prop in _FONT_PROPS:
+        return _to_font_size(value)
     return normalize_macro_syntax(value) if isinstance(value, str) else value
 
 
@@ -192,8 +212,9 @@ def edm_color_to_hex(value: Any, color_data: dict[str, Any] | None) -> str | Non
 
 # Classes whose registry definition maps a readback channel (readbackChannel ->
 # pv-button's readbackPV). Elsewhere a second data channel has nowhere to land
-# and is dropped with a warning.
-_READBACK_CLASSES = {"activebuttonclass", "activemessagebuttonclass"}
+# and is dropped with a warning. Menu buttons pair controlPv with an
+# indicatorPv readback exactly like plain buttons (batch-2: cbxfel camera rows).
+_READBACK_CLASSES = {"activebuttonclass", "activemessagebuttonclass", "activemenubuttonclass"}
 
 # EDM alarm-severity palette (green / yellow / red / white-invalid) — what an
 # alarm-sensitive EDM part shows instead of its configured static color.
@@ -606,6 +627,25 @@ def _pip_rules(obj: EDMObject) -> list[RuleSpec]:
     ]
 
 
+def _fixup_choice_button(obj: EDMObject, qt_props: dict[str, Any], warnings: list[str]) -> Geometry | None:
+    """activeChoiceButtonClass fixup: EDM lays the states out to fill the rect —
+    wide boxes read horizontally, tall boxes vertically."""
+    qt_props["orientation"] = "horizontal" if obj.width >= obj.height else "vertical"
+    return None
+
+
+def _fixup_menu_button(obj: EDMObject, qt_props: dict[str, Any], warnings: list[str]) -> Geometry | None:
+    """activeMenuButtonClass fixup: the button face shows the CURRENT choice
+    (EDM renders the enum string of its PV), so the web button uses pvState
+    labeling; without an explicit indicatorPv the control channel doubles as
+    the state source.
+    """
+    qt_props["labelType"] = "pvState"
+    if "readbackChannel" not in qt_props and qt_props.get("channel"):
+        qt_props["readbackChannel"] = qt_props["channel"]
+    return None
+
+
 def _fixup_meter(obj: EDMObject, qt_props: dict[str, Any], warnings: list[str]) -> Geometry | None:
     """activeMeterClass fixup: warn when labelType isn't the literal-text default.
 
@@ -639,6 +679,8 @@ _CLASS_FIXUPS.update(
         "activeindicatorclass": _fixup_bar,
         "activemessagebuttonclass": _fixup_state_button,
         "activebuttonclass": _fixup_state_button,
+        "activechoicebuttonclass": _fixup_choice_button,
+        "activemenubuttonclass": _fixup_menu_button,
         "xygraphclass": _fixup_xy_graph,
         "activepipclass": _fixup_pip,
         # activepngclass, activeradiobuttonclass: no fixup needed; global renames suffice.
@@ -669,7 +711,10 @@ def _object_to_source(obj: EDMObject, colors: dict[str, Any] | None = None) -> S
                     continue
                 qt_props[qt_prop] = hex_color
                 continue
-            qt_props[qt_prop] = _coerce(qt_prop, value)
+            coerced = _coerce(qt_prop, value)
+            if qt_prop in _FONT_PROPS and coerced is None:
+                continue  # malformed font string: no size beats a wrong size
+            qt_props[qt_prop] = coerced
         _apply_channel_attrs(obj, qt_props, warnings)
         rules = _alarm_rules(obj) + _pip_rules(obj)
         if any(rule.target_property == "foregroundColor" for rule in rules):

--- a/pydmconverter/edm/parser.py
+++ b/pydmconverter/edm/parser.py
@@ -62,7 +62,13 @@ class EDMFileParser:
     #    re.DOTALL | re.MULTILINE,
     # )
 
-    def __init__(self, file_path: str | Path, output_file_path: str | Path, calc_list_file: str | None = None):
+    def __init__(
+        self,
+        file_path: str | Path,
+        output_file_path: str | Path,
+        calc_list_file: str | None = None,
+        calc_reuse_short: bool = True,
+    ):
         """Creates an instance of EDMFileParser for the given file_path
 
         Parameters
@@ -71,12 +77,17 @@ class EDMFileParser:
             EDM file to parse
         calc_list_file : str, optional
             Explicit path to a calc.list file used to resolve named CALC PVs
+        calc_reuse_short : bool, optional
+            Emit short ``calc://<id>`` reuse forms after a calc's first
+            appearance (PyDM plugin semantics). The react/IR target passes
+            False so every occurrence keeps its full query for formula hoisting.
         """
         if not Path(file_path).exists():
             raise FileNotFoundError(f"File not found: {file_path}")
         self.file_path = file_path
         self.output_file_path = output_file_path
         self.calc_list_file = calc_list_file
+        self.calc_reuse_short = calc_reuse_short
 
         try:
             with open(file_path, "r") as file:
@@ -102,7 +113,9 @@ class EDMFileParser:
         )  # remove global macros TODO: In edm, these macros (!W) and (!A) are used to specify the scope of the macros (outside of a specific screen) this may need to be resolved more cleanly later
         pattern = r"\\*\$\(([^)]+)\)"
         self.text = re.sub(pattern, r"${\1}", self.text)
-        self.text, _, _ = replace_calc_and_loc_in_edm_content(self.text, file_path, self.calc_list_file)
+        self.text, _, _ = replace_calc_and_loc_in_edm_content(
+            self.text, file_path, self.calc_list_file, calc_reuse_short=self.calc_reuse_short
+        )
         return self.text
 
     def parse_screen_properties(self) -> None:
@@ -262,7 +275,13 @@ class EDMFileParser:
             return EDMGroup()
         if not embedded_file.endswith(".edl"):
             embedded_file += ".edl"
-        edm_paths = os.environ.get("EDMDATAFILES", ".").split(":")
+        # EDM resolves symbol files beside the calling display first, then along
+        # EDMDATAFILES. Split on ":" only when it is not a Windows drive colon
+        # (":" followed by a path separator), and accept ";" separators too.
+        edm_paths: list[str] = [str(Path(self.file_path).parent)]
+        datafiles = os.environ.get("EDMDATAFILES", ".")
+        for chunk in datafiles.split(";"):
+            edm_paths.extend(p for p in re.split(r":(?![\\/])", chunk) if p)
         embedded_text = None
         for path in edm_paths:
             full_path = Path(path) / embedded_file
@@ -271,6 +290,7 @@ class EDMFileParser:
                     embedded_text = file.read()
                 break
         if embedded_text is None:
+            logger.warning(f"Symbol file {embedded_file!r} not found beside the display or on EDMDATAFILES")
             return EDMGroup()
 
         temp_group = EDMGroup()

--- a/pydmconverter/edm/parser_helpers.py
+++ b/pydmconverter/edm/parser_helpers.py
@@ -44,6 +44,12 @@ def search_calc_list(file_path: str, cli_calc_file: Optional[str] = None) -> Opt
     if edmfiles:
         candidates.append(os.path.join(edmfiles, "calc.list"))
 
+    # A site colors.list usually lives in the EDM config dir, and calc.list
+    # sits beside it — so EDMCOLORFILE localizes calc.list too.
+    color_file = os.environ.get("EDMCOLORFILE", "")
+    if color_file:
+        candidates.append(os.path.join(os.path.dirname(color_file), "calc.list"))
+
     for candidate in candidates:
         if os.path.isfile(candidate):
             return candidate
@@ -580,7 +586,7 @@ def loc_conversion(edm_string: str) -> str:
 
 
 def replace_calc_and_loc_in_edm_content(
-    edm_content: str, filepath: str, calc_list_file: Optional[str] = None
+    edm_content: str, filepath: str, calc_list_file: Optional[str] = None, calc_reuse_short: bool = True
 ) -> Tuple[str, Dict[str, Dict[str, str]], Dict[str, Dict[str, str]]]:
     """
     Replace both CALC\\...(...) and LOC\\...=... references in the EDM file content
@@ -596,6 +602,11 @@ def replace_calc_and_loc_in_edm_content(
     calc_list_file : str, optional
         An explicit path to a calc.list file used to resolve named CALC PVs.
         Overrides the default calc.list search locations.
+    calc_reuse_short : bool, optional
+        When True (the PyDM target), the second and later appearances of a calc
+        use the short ``calc://<id>`` form (the plugin reuses the registered
+        config). The react/IR target passes False: every appearance carries the
+        full query so the formula hoister can lower each one independently.
 
     Returns
     -------
@@ -630,7 +641,7 @@ def replace_calc_and_loc_in_edm_content(
             encountered_calcs[edm_pv] = {"full": full_url, "short": short_url}
             return full_url
         else:
-            return encountered_calcs[edm_pv]["short"]
+            return encountered_calcs[edm_pv]["short" if calc_reuse_short else "full"]
 
     new_content = calc_pattern.sub(replace_calc_match, edm_content)
 

--- a/pydmconverter/ir/builder.py
+++ b/pydmconverter/ir/builder.py
@@ -61,6 +61,7 @@ class IRBuilder:
         size: tuple[Number, Number],
         top_level: list[SourceNode],
         macros: list[MacroDeclaration] | None = None,
+        background: str | None = None,
     ) -> ScreenIR:
         """Assemble a screen: an ``absolute-canvas`` root wrapping the top-level nodes.
 
@@ -79,10 +80,15 @@ class IRBuilder:
             width = max_x + MARGIN
         if max_y + MARGIN > height:
             height = max_y + MARGIN
+        root_props: dict = {"width": width, "height": height}
+        if background:
+            # The legacy display's field color; the renderer paints the canvas
+            # with it so converted screens don't sit on the app theme background.
+            root_props["backgroundColor"] = background
         root = WidgetNode(
             id=root_id,
             type=self.root_type,
-            props={"width": width, "height": height},
+            props=root_props,
             geometry=Geometry(x=0, y=0, width=width, height=height),
             children=children,
         )

--- a/pydmconverter/ir/builder.py
+++ b/pydmconverter/ir/builder.py
@@ -167,7 +167,12 @@ class IRBuilder:
         )
 
     def _build_rules(self, specs: list[RuleSpec]) -> list[Rule]:
-        """Turn id-less RuleSpecs into Rules with allocated ``r-NNN`` ids."""
+        """Turn id-less RuleSpecs into Rules with allocated ``r-NNN`` ids.
+
+        Rule PVs that are ``calc://`` URLs (EDM CALC channels driving e.g.
+        visibility) are hoisted into screen formulas and referenced as
+        ``fox://<name>`` — the rule compiler inlines those client-side.
+        """
         rules: list[Rule] = []
         for spec in specs:
             rules.append(
@@ -175,12 +180,21 @@ class IRBuilder:
                     id=self.ids.rule(),
                     name=spec.name,
                     target_property=spec.target_property,
-                    pvs=[RulePV(name=name, trigger=trigger) for name, trigger in spec.pvs],
+                    pvs=[RulePV(name=self._hoist_pv(name), trigger=trigger) for name, trigger in spec.pvs],
                     conditions=[RuleCondition(expression=expr, value=value) for expr, value in spec.conditions],
                     default=spec.default,
                 )
             )
         return rules
+
+    def _hoist_pv(self, name: str) -> str:
+        """Lower a ``calc://`` PV reference to its ``fox://`` formula ref."""
+        if isinstance(name, str) and name.startswith("calc://"):
+            parsed = parse_calc_url(name)
+            if parsed:
+                expression, bindings = parsed
+                return f"fox://{self.formulas.intern(expression, bindings)}"
+        return name
 
     @staticmethod
     def _content_extent(nodes: list[WidgetNode]) -> tuple[Number, Number]:
@@ -206,10 +220,23 @@ class IRBuilder:
         return Geometry(x=x, y=y, width=width, height=height)
 
     def _collect_macros(self, root: WidgetNode) -> list[MacroDeclaration]:
-        """Declare every ``${VAR}`` referenced in any string prop, default ``""``."""
+        """Declare every ``${VAR}`` referenced in any string prop, default ``""``.
+
+        Recurses into structured props — action lists (shell commands, display
+        targets), macro dicts, curve JSON strings — where macro refs otherwise
+        hid undeclared.
+        """
         names: dict[str, None] = {}
 
         def note(value: object) -> None:
+            if isinstance(value, dict):
+                for item in value.values():
+                    note(item)
+                return
+            if isinstance(value, (list, tuple)):
+                for item in value:
+                    note(item)
+                return
             for ref in find_macro_references(value):
                 names.setdefault(ref, None)
 

--- a/pydmconverter/ir/data/widget-registry/absolute-canvas.json
+++ b/pydmconverter/ir/data/widget-registry/absolute-canvas.json
@@ -17,7 +17,8 @@
     "required": ["width", "height"],
     "properties": {
       "width": { "type": "integer", "minimum": 1 },
-      "height": { "type": "integer", "minimum": 1 }
+      "height": { "type": "integer", "minimum": 1 },
+      "backgroundColor": { "type": "string" }
     }
   },
 

--- a/pydmconverter/ir/data/widget-registry/polygon.json
+++ b/pydmconverter/ir/data/widget-registry/polygon.json
@@ -63,6 +63,7 @@
     "penWidth": { "to": "lineWidth" },
     "penStyle": { "to": "lineStyle", "transform": "edmLineStyle" },
     "points": { "to": "points", "transform": "parsePoints" },
+    "closePolygon": { "to": "closed" },
     "brushFill": { "to": "fill" },
     "brushColor": { "to": "fillColor" },
     "opacity": { "to": "opacity" }

--- a/pydmconverter/ir/data/widget-registry/pv-button.json
+++ b/pydmconverter/ir/data/widget-registry/pv-button.json
@@ -5,73 +5,176 @@
   "description": "Action button that writes press/release values to a PV.",
   "category": "controls",
   "paletteIcon": "pv-button.svg",
-
   "reactComponent": {
     "name": "PVButton",
     "module": "@canopy/widgets"
   },
-
   "qtMapping": {
     "class": "PyDMPushButton",
     "extends": "QPushButton",
     "header": "pydm.widgets.pushbutton"
   },
-
   "propSchema": {
     "$schema": "https://json-schema.org/draft-07/schema",
     "type": "object",
-    "required": ["pv"],
+    "required": [
+      "pv"
+    ],
     "properties": {
-      "pv": { "type": "string", "format": "pv-channel" },
+      "pv": {
+        "type": "string",
+        "format": "pv-channel"
+      },
       "readbackPV": {
         "type": "string",
         "format": "pv-channel",
         "description": "State source for toggle/on-off labeling (EDM indicatorPv); pv stays the write channel."
       },
-      "label": { "type": "string" },
-      "onLabel": { "type": "string" },
-      "offLabel": { "type": "string" },
+      "label": {
+        "type": "string"
+      },
+      "onLabel": {
+        "type": "string"
+      },
+      "offLabel": {
+        "type": "string"
+      },
       "buttonType": {
         "type": "string",
-        "enum": ["push", "toggle"],
+        "enum": [
+          "push",
+          "toggle"
+        ],
         "default": "push"
       },
       "kind": {
         "type": "string",
-        "enum": ["primary", "secondary", "tertiary", "danger", "ghost"],
+        "enum": [
+          "primary",
+          "secondary",
+          "tertiary",
+          "danger",
+          "ghost"
+        ],
         "default": "primary"
       },
-      "iconOnly": { "type": "boolean", "default": false },
-      "pressValue": { "type": ["number", "string"] },
-      "releaseValue": { "type": ["number", "string"] },
+      "iconOnly": {
+        "type": "boolean",
+        "default": false
+      },
+      "pressValue": {
+        "type": [
+          "number",
+          "string"
+        ]
+      },
+      "releaseValue": {
+        "type": [
+          "number",
+          "string"
+        ]
+      },
       "fontSize": {
         "type": "number",
         "title": "Font Size (px)"
+      },
+      "labelType": {
+        "type": "string",
+        "enum": [
+          "literal",
+          "pvState"
+        ],
+        "default": "literal",
+        "description": "pvState renders the readback PV's current enum string as the face text (EDM menu-button behavior)."
+      },
+      "onColor": {
+        "type": "string"
+      },
+      "offColor": {
+        "type": "string"
+      },
+      "foregroundColor": {
+        "type": "string"
+      },
+      "backgroundColor": {
+        "type": "string"
       }
     }
   },
-
   "qtPropMap": {
-    "channel": { "to": "pv", "transform": "stripProtocol" },
-    "readbackChannel": { "to": "readbackPV", "transform": "stripProtocol" },
-    "pressValue": { "to": "pressValue" },
-    "releaseValue": { "to": "releaseValue" },
-    "text": { "to": "label" },
-    "onLabel": { "to": "onLabel" },
-    "offLabel": { "to": "offLabel" },
-    "buttonType": { "to": "buttonType" },
-    "fontSize": { "to": "fontSize" }
+    "channel": {
+      "to": "pv",
+      "transform": "stripProtocol"
+    },
+    "readbackChannel": {
+      "to": "readbackPV",
+      "transform": "stripProtocol"
+    },
+    "pressValue": {
+      "to": "pressValue"
+    },
+    "releaseValue": {
+      "to": "releaseValue"
+    },
+    "text": {
+      "to": "label"
+    },
+    "onLabel": {
+      "to": "onLabel"
+    },
+    "offLabel": {
+      "to": "offLabel"
+    },
+    "buttonType": {
+      "to": "buttonType"
+    },
+    "fontSize": {
+      "to": "fontSize"
+    },
+    "labelType": {
+      "to": "labelType"
+    },
+    "onColor": {
+      "to": "onColor"
+    },
+    "offColor": {
+      "to": "offColor"
+    },
+    "foregroundColor": {
+      "to": "foregroundColor"
+    },
+    "backgroundColor": {
+      "to": "backgroundColor"
+    }
   },
-
   "inspectorSchema": {
     "groups": [
-      { "name": "PV", "fields": ["pv", "readbackPV", "pressValue", "releaseValue"] },
-      { "name": "Display", "fields": ["label", "onLabel", "offLabel", "buttonType", "kind", "iconOnly"] }
+      {
+        "name": "PV",
+        "fields": [
+          "pv",
+          "readbackPV",
+          "pressValue",
+          "releaseValue"
+        ]
+      },
+      {
+        "name": "Display",
+        "fields": [
+          "label",
+          "onLabel",
+          "offLabel",
+          "buttonType",
+          "kind",
+          "iconOnly"
+        ]
+      }
     ]
   },
-
-  "defaults": { "width": 100, "height": 32 },
-
+  "defaults": {
+    "width": 100,
+    "height": 32
+  },
   "supportsPv": true,
   "supportsRules": true,
   "supportsChildren": false

--- a/pydmconverter/ir/data/widget-registry/pv-button.json
+++ b/pydmconverter/ir/data/widget-registry/pv-button.json
@@ -23,7 +23,19 @@
     "required": ["pv"],
     "properties": {
       "pv": { "type": "string", "format": "pv-channel" },
+      "readbackPV": {
+        "type": "string",
+        "format": "pv-channel",
+        "description": "State source for toggle/on-off labeling (EDM indicatorPv); pv stays the write channel."
+      },
       "label": { "type": "string" },
+      "onLabel": { "type": "string" },
+      "offLabel": { "type": "string" },
+      "buttonType": {
+        "type": "string",
+        "enum": ["push", "toggle"],
+        "default": "push"
+      },
       "kind": {
         "type": "string",
         "enum": ["primary", "secondary", "tertiary", "danger", "ghost"],
@@ -41,16 +53,20 @@
 
   "qtPropMap": {
     "channel": { "to": "pv", "transform": "stripProtocol" },
+    "readbackChannel": { "to": "readbackPV", "transform": "stripProtocol" },
     "pressValue": { "to": "pressValue" },
     "releaseValue": { "to": "releaseValue" },
     "text": { "to": "label" },
+    "onLabel": { "to": "onLabel" },
+    "offLabel": { "to": "offLabel" },
+    "buttonType": { "to": "buttonType" },
     "fontSize": { "to": "fontSize" }
   },
 
   "inspectorSchema": {
     "groups": [
-      { "name": "PV", "fields": ["pv", "pressValue", "releaseValue"] },
-      { "name": "Display", "fields": ["label", "kind", "iconOnly"] }
+      { "name": "PV", "fields": ["pv", "readbackPV", "pressValue", "releaseValue"] },
+      { "name": "Display", "fields": ["label", "onLabel", "offLabel", "buttonType", "kind", "iconOnly"] }
     ]
   },
 

--- a/pydmconverter/ir/data/widget-registry/pv-byte-led.json
+++ b/pydmconverter/ir/data/widget-registry/pv-byte-led.json
@@ -5,53 +5,107 @@
   "description": "Multi-bit status indicator: a row of LEDs driven by individual bits of an integer PV.",
   "category": "indicators",
   "paletteIcon": "pv-byte-led.svg",
-
   "reactComponent": {
     "name": "PVByteLed",
     "module": "@canopy/widgets"
   },
-
   "qtMapping": {
     "class": "PyDMByteIndicator",
     "extends": "QWidget",
     "header": "pydm.widgets.byte"
   },
-
   "propSchema": {
     "$schema": "https://json-schema.org/draft-07/schema",
     "type": "object",
-    "required": ["pv", "numBits"],
+    "required": [
+      "pv",
+      "numBits"
+    ],
     "properties": {
-      "pv": { "type": "string", "format": "pv-channel" },
-      "numBits": { "type": "integer", "minimum": 1, "maximum": 64, "default": 8 },
-      "shift": { "type": "integer", "minimum": 0, "default": 0 },
+      "pv": {
+        "type": "string",
+        "format": "pv-channel"
+      },
+      "numBits": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 64,
+        "default": 8
+      },
+      "shift": {
+        "type": "integer",
+        "minimum": 0,
+        "default": 0
+      },
       "orientation": {
         "type": "string",
-        "enum": ["horizontal", "vertical"],
+        "enum": [
+          "horizontal",
+          "vertical"
+        ],
         "default": "horizontal"
       },
-      "onColor": { "type": "string", "default": "#3ddc84" },
-      "offColor": { "type": "string", "default": "#444444" }
+      "onColor": {
+        "type": "string",
+        "default": "#3ddc84"
+      },
+      "offColor": {
+        "type": "string",
+        "default": "#444444"
+      }
     }
   },
-
   "qtPropMap": {
-    "channel": { "to": "pv", "transform": "stripProtocol" },
-    "numBits": { "to": "numBits" },
-    "shift": { "to": "shift" },
-    "orientation": { "to": "orientation", "transform": "qtOrientation" }
+    "channel": {
+      "to": "pv",
+      "transform": "stripProtocol"
+    },
+    "numBits": {
+      "to": "numBits"
+    },
+    "shift": {
+      "to": "shift"
+    },
+    "orientation": {
+      "to": "orientation",
+      "transform": "qtOrientation"
+    },
+    "onColor": {
+      "to": "onColor"
+    },
+    "offColor": {
+      "to": "offColor"
+    }
   },
-
   "inspectorSchema": {
     "groups": [
-      { "name": "PV", "fields": ["pv"] },
-      { "name": "Bits", "fields": ["numBits", "shift"] },
-      { "name": "Display", "fields": ["orientation", "onColor", "offColor"] }
+      {
+        "name": "PV",
+        "fields": [
+          "pv"
+        ]
+      },
+      {
+        "name": "Bits",
+        "fields": [
+          "numBits",
+          "shift"
+        ]
+      },
+      {
+        "name": "Display",
+        "fields": [
+          "orientation",
+          "onColor",
+          "offColor"
+        ]
+      }
     ]
   },
-
-  "defaults": { "width": 200, "height": 24 },
-
+  "defaults": {
+    "width": 200,
+    "height": 24
+  },
   "supportsPv": true,
   "supportsRules": true,
   "supportsChildren": false

--- a/pydmconverter/ir/data/widget-registry/pv-led.json
+++ b/pydmconverter/ir/data/widget-registry/pv-led.json
@@ -5,45 +5,87 @@
   "description": "Status indicator that lights up based on a PV value.",
   "category": "indicators",
   "paletteIcon": "pv-led.svg",
-
   "reactComponent": {
     "name": "PVLed",
     "module": "@canopy/widgets"
   },
-
   "qtMapping": {
     "class": "PyDMSymbol",
     "extends": "QWidget",
     "header": "pydm.widgets.symbol"
   },
-
   "propSchema": {
     "$schema": "https://json-schema.org/draft-07/schema",
     "type": "object",
-    "required": ["pv"],
+    "required": [
+      "pv"
+    ],
     "properties": {
-      "pv": { "type": "string", "format": "pv-channel" },
-      "onValue": { "type": ["number", "string"], "default": 1 },
-      "onColor": { "type": "string", "default": "#3ddc84" },
-      "offColor": { "type": "string", "default": "#888888" },
-      "alarmSensitive": { "type": "boolean", "default": true }
+      "pv": {
+        "type": "string",
+        "format": "pv-channel"
+      },
+      "onValue": {
+        "type": [
+          "number",
+          "string"
+        ],
+        "default": 1
+      },
+      "onColor": {
+        "type": "string",
+        "default": "#3ddc84"
+      },
+      "offColor": {
+        "type": "string",
+        "default": "#888888"
+      },
+      "alarmSensitive": {
+        "type": "boolean",
+        "default": true
+      }
     }
   },
-
   "qtPropMap": {
-    "channel": { "to": "pv", "transform": "stripProtocol" }
+    "channel": {
+      "to": "pv",
+      "transform": "stripProtocol"
+    },
+    "onColor": {
+      "to": "onColor"
+    },
+    "offColor": {
+      "to": "offColor"
+    }
   },
-
   "inspectorSchema": {
     "groups": [
-      { "name": "PV", "fields": ["pv", "onValue"] },
-      { "name": "Appearance", "fields": ["onColor", "offColor"] },
-      { "name": "Alarm", "fields": ["alarmSensitive"] }
+      {
+        "name": "PV",
+        "fields": [
+          "pv",
+          "onValue"
+        ]
+      },
+      {
+        "name": "Appearance",
+        "fields": [
+          "onColor",
+          "offColor"
+        ]
+      },
+      {
+        "name": "Alarm",
+        "fields": [
+          "alarmSensitive"
+        ]
+      }
     ]
   },
-
-  "defaults": { "width": 24, "height": 24 },
-
+  "defaults": {
+    "width": 24,
+    "height": 24
+  },
   "supportsPv": true,
   "supportsRules": true,
   "supportsChildren": false

--- a/pydmconverter/ir/fox.py
+++ b/pydmconverter/ir/fox.py
@@ -21,10 +21,39 @@ from pydmconverter.ir.macros import normalize_macro_syntax
 _CHANNEL_PREFIXES = ("channel://", "ca://", "pva://")
 _NUMERIC = re.compile(r"^[+-]?(\d+\.?\d*|\.\d+)$")
 
+# EPICS CALC function names -> Fox namespace names (Canopy
+# src/canopy/fox/language/namespace.py). EPICS SQR is square ROOT; LOG is
+# log10 and LOGE/LN the natural log. Unknown names pass through and surface
+# via Fox validation instead of being guessed at.
+_CALC_TO_FOX_FUNCTIONS = {
+    "MAX": "max",
+    "MIN": "min",
+    "ABS": "abs",
+    "SQR": "sqrt",
+    "SQRT": "sqrt",
+    "EXP": "exp",
+    "LOG": "log10",
+    "LOGE": "log",
+    "LN": "log",
+    "CEIL": "ceil",
+    "FLOOR": "floor",
+    "SIN": "sin",
+    "COS": "cos",
+    "TAN": "tan",
+    "ASIN": "asin",
+    "ACOS": "acos",
+    "ATAN": "atan",
+    "ATAN2": "atan2",
+}
+_CALC_FUNCTION_RE = re.compile(r"\b(" + "|".join(_CALC_TO_FOX_FUNCTIONS) + r")\s*\(")
+
 
 def to_fox_expression(expression: str) -> str:
-    """Convert EPICS calc operators to Fox/Python. Idempotent (already applied at parse)."""
-    return expression.replace("^", "**").replace("#", "!=")
+    """Convert EPICS calc operators/functions to Fox/Python. Idempotent (the
+    parser already applies the operator conversions; function names are only
+    rewritten as call sites, so single-letter variables are never touched)."""
+    expression = expression.replace("^", "**").replace("#", "!=")
+    return _CALC_FUNCTION_RE.sub(lambda m: _CALC_TO_FOX_FUNCTIONS[m.group(1)] + "(", expression)
 
 
 def _strip_channel(value: str) -> str:

--- a/pydmconverter/react.py
+++ b/pydmconverter/react.py
@@ -33,6 +33,8 @@ def convert_to_ir(
     *,
     registry: RegistryClient | None = None,
     color_list_path: str | Path | None = None,
+    calc_list_path: str | Path | None = None,
+    site: str | None = None,
 ) -> ScreenIR:
     """Parse an ``.edl`` or ``.ui`` file into a Screen IR, dispatching by suffix.
 
@@ -45,7 +47,13 @@ def convert_to_ir(
     if adapter is None:
         raise ValueError(f"--target react supports {', '.join(SUPPORTED_SUFFIXES)} inputs, not {suffix!r}")
     if suffix == ".edl":
-        return edm_file_to_ir(input_path, registry=registry, color_list_path=color_list_path)
+        return edm_file_to_ir(
+            input_path,
+            registry=registry,
+            color_list_path=color_list_path,
+            calc_list_path=calc_list_path,
+            site=site,
+        )
     return ui_file_to_ir(input_path, registry=registry)
 
 
@@ -55,6 +63,8 @@ def convert_bytes(
     kind: Literal["edl", "ui"],
     registry: RegistryClient | None = None,
     color_list_path: str | Path | None = None,
+    calc_list_path: str | Path | None = None,
+    site: str | None = None,
 ) -> ScreenIR:
     """Parse raw ``.edl``/``.ui`` bytes into a Screen IR, keyed on ``kind``.
 
@@ -75,7 +85,9 @@ def convert_bytes(
     try:
         staged = tmp_dir / f"screen.{kind}"
         staged.write_bytes(data)
-        return convert_to_ir(staged, registry=registry, color_list_path=color_list_path)
+        return convert_to_ir(
+            staged, registry=registry, color_list_path=color_list_path, calc_list_path=calc_list_path, site=site
+        )
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
 
@@ -94,6 +106,8 @@ def convert_file(
     override: bool = False,
     registry: RegistryClient | None = None,
     color_list_path: str | Path | None = None,
+    calc_list_path: str | Path | None = None,
+    site: str | None = None,
 ) -> Path:
     """Convert one ``.edl``/``.ui`` file to ``*.screen.json``; return the output path.
 
@@ -105,7 +119,12 @@ def convert_file(
     out = _screen_json_path(inp, Path(output_path))
     if out.is_file() and not override:
         raise FileExistsError(f"Output file '{out}' already exists. Use --override or -o to overwrite it.")
-    return write_screen_json(convert_to_ir(inp, registry=registry, color_list_path=color_list_path), out)
+    return write_screen_json(
+        convert_to_ir(
+            inp, registry=registry, color_list_path=color_list_path, calc_list_path=calc_list_path, site=site
+        ),
+        out,
+    )
 
 
 def convert_folder(
@@ -115,6 +134,8 @@ def convert_folder(
     override: bool = False,
     registry: RegistryClient | None = None,
     color_list_path: str | Path | None = None,
+    calc_list_path: str | Path | None = None,
+    site: str | None = None,
 ) -> tuple[int, list[str]]:
     """Recursively convert every ``.edl``/``.ui`` under ``input_dir``.
 
@@ -139,7 +160,16 @@ def convert_folder(
             logger.warning("Skipped: %s already exists. Use --override or -o to overwrite it.", out)
             continue
         try:
-            write_screen_json(convert_to_ir(source, registry=registry, color_list_path=color_list_path), out)
+            write_screen_json(
+                convert_to_ir(
+                    source,
+                    registry=registry,
+                    color_list_path=color_list_path,
+                    calc_list_path=calc_list_path,
+                    site=site,
+                ),
+                out,
+            )
         except Exception as exc:  # noqa: BLE001 - report and continue the walk
             failed.append(str(source))
             logger.warning("Failed to convert %s: %s", source, exc)

--- a/tests/edm/fixtures/calc.list
+++ b/tests/edm/fixtures/calc.list
@@ -1,0 +1,5 @@
+CALC1
+
+# two-input summary
+sum
+A+B

--- a/tests/edm/fixtures/calc_rules.edl
+++ b/tests/edm/fixtures/calc_rules.edl
@@ -1,0 +1,62 @@
+4 0 1
+beginScreenProperties
+major 4
+minor 0
+release 1
+x 0
+y 0
+w 300
+h 200
+font "helvetica-medium-r-12.0"
+ctlFont "helvetica-medium-r-12.0"
+btnFont "helvetica-medium-r-12.0"
+fgColor index 14
+bgColor index 4
+textColor index 14
+endScreenProperties
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 10
+y 10
+w 50
+h 20
+lineColor index 14
+visPv "CALC\\{MAX(A,B)}(SIG:ONE.SEVR,SIG:TWO.SEVR)"
+visMin "1"
+visMax "5"
+endObjectProperties
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 10
+y 40
+w 50
+h 20
+lineColor index 14
+visPv "CALC\\{MAX(A,B)}(SIG:ONE.SEVR,SIG:TWO.SEVR)"
+visMin "1"
+visMax "5"
+endObjectProperties
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 10
+y 70
+w 50
+h 20
+lineColor index 14
+visPv "CALC\\sum(LOC\\posVis=i:0,LOC\\ctlVis=i:0)"
+endObjectProperties

--- a/tests/edm/fixtures/integration_combined.screen.json
+++ b/tests/edm/fixtures/integration_combined.screen.json
@@ -208,7 +208,8 @@
             {
               "type": "close_display"
             }
-          ]
+          ],
+          "fontSize": 12
         },
         "geometry": {
           "x": 420,
@@ -237,7 +238,8 @@
         "id": "w-012",
         "type": "pv-radio-group",
         "props": {
-          "pv": "${P}:MODE"
+          "pv": "${P}:MODE",
+          "fontSize": 12
         },
         "geometry": {
           "x": 200,

--- a/tests/edm/fixtures/pip_menu.edl
+++ b/tests/edm/fixtures/pip_menu.edl
@@ -1,0 +1,92 @@
+4 0 1
+beginScreenProperties
+major 4
+minor 0
+release 1
+x 100
+y 100
+w 400
+h 300
+font "helvetica-medium-r-12.0"
+ctlFont "helvetica-medium-r-12.0"
+btnFont "helvetica-medium-r-12.0"
+fgColor index 14
+bgColor index 4
+textColor index 14
+ctlFgColor1 index 25
+ctlFgColor2 index 25
+ctlBgColor1 index 3
+ctlBgColor2 index 3
+topShadowColor index 1
+botShadowColor index 11
+endScreenProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 20
+y 20
+w 233
+h 137
+fgColor index 14
+bgColor index 3
+topShadowColor index 3
+botShadowColor index 3
+displaySource "menu"
+filePv "$(TEMLOCATION):INAPOSITION"
+numDsps 2
+displayFileName {
+  0 "TEMnocentroid"
+  1 "TEMcentroid"
+}
+menuLabel {
+  0 "Not in position"
+  1 "In Position"
+}
+noScroll
+endObjectProperties
+
+# (Embedded Window)
+object activePipClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 20
+y 170
+w 233
+h 100
+fgColor index 14
+bgColor index 3
+topShadowColor index 3
+botShadowColor index 3
+file "mgnt_unit_$(DISP)"
+sizeOfs 5
+numDsps 0
+noScroll
+endObjectProperties
+
+# (Shell Command)
+object shellCmdClass
+beginObjectProperties
+major 4
+minor 3
+release 0
+x 280
+y 20
+w 100
+h 24
+fgColor index 14
+bgColor index 3
+topShadowColor index 1
+botShadowColor index 11
+font "helvetica-medium-r-12.0"
+buttonLabel "Strip"
+numCmds 1
+command {
+  0 "StripTool $(STRIPCONFIG)"
+}
+endObjectProperties

--- a/tests/edm/fixtures/symbol_states.edl
+++ b/tests/edm/fixtures/symbol_states.edl
@@ -1,0 +1,80 @@
+4 0 1
+beginScreenProperties
+major 4
+minor 0
+release 1
+x 0
+y 0
+w 200
+h 100
+font "helvetica-medium-r-12.0"
+ctlFont "helvetica-medium-r-12.0"
+btnFont "helvetica-medium-r-12.0"
+fgColor index 14
+bgColor index 4
+textColor index 14
+endScreenProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 0
+y 0
+w 24
+h 24
+
+beginGroup
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 0
+y 0
+w 24
+h 24
+lineColor index 14
+fill
+fillColor index 15
+endObjectProperties
+
+endGroup
+
+endObjectProperties
+
+# (Group)
+object activeGroupClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 40
+y 0
+w 24
+h 24
+
+beginGroup
+
+# (Circle)
+object activeCircleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 40
+y 0
+w 24
+h 24
+lineColor index 14
+fill
+fillColor index 20
+endObjectProperties
+
+endGroup
+
+endObjectProperties

--- a/tests/edm/fixtures/symbol_two_state.edl
+++ b/tests/edm/fixtures/symbol_two_state.edl
@@ -1,0 +1,44 @@
+4 0 1
+beginScreenProperties
+major 4
+minor 0
+release 1
+x 100
+y 100
+w 300
+h 200
+font "helvetica-medium-r-12.0"
+ctlFont "helvetica-medium-r-12.0"
+btnFont "helvetica-medium-r-12.0"
+fgColor index 14
+bgColor index 4
+textColor index 14
+endScreenProperties
+
+# (Symbol)
+object activeSymbolClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 50
+y 60
+w 24
+h 24
+file "symbol_states"
+numStates 2
+minValues {
+  0 0
+  1 1
+}
+maxValues {
+  0 1
+  1 2
+}
+controlPvs {
+  0 "$(dev):MOTOR_STATE"
+}
+numPvs 1
+useOriginalSize
+useOriginalColors
+endObjectProperties

--- a/tests/edm/test_batch2_widget_fixes.py
+++ b/tests/edm/test_batch2_widget_fixes.py
@@ -1,0 +1,76 @@
+"""Batch-2 regressions: EDM font sizes reach the IR, choice buttons render as
+radio sets, menu buttons show their current choice, and state colors map."""
+
+from pydmconverter.edm.edm_qt import EDM_TO_QT_CLASS
+from pydmconverter.edm.ir_adapter import (
+    _fixup_choice_button,
+    _object_to_source,
+    _to_font_size,
+)
+from pydmconverter.edm.parser import EDMObject
+
+
+def _obj(name, properties, w=10, h=10):
+    obj = EDMObject.__new__(EDMObject)
+    obj.name = name
+    obj.properties = properties
+    obj.x, obj.y, obj.width, obj.height = 0, 0, w, h
+    return obj
+
+
+def test_font_string_becomes_pixel_size():
+    assert _to_font_size("helvetica-medium-r-12.0") == 12
+    assert _to_font_size("helvetica-bold-r-14.0") == 14
+    assert _to_font_size("courier-medium-r-8.0") == 8
+    assert _to_font_size("garbage") is None
+
+
+def test_font_flows_into_qt_props_and_malformed_is_dropped():
+    node = _object_to_source(_obj("activeXTextClass", {"value": ["hi"], "font": "helvetica-bold-r-10.0"}))
+    assert node.qt_props["fontSize"] == 10
+    node = _object_to_source(_obj("activeXTextClass", {"value": ["hi"], "font": "weird"}))
+    assert "fontSize" not in node.qt_props
+
+
+def test_choice_button_is_a_radio_set_with_aspect_orientation():
+    assert EDM_TO_QT_CLASS["activechoicebuttonclass"] == "PyDMEnumButton"
+    qt_props = {}
+    _fixup_choice_button(_obj("activeChoiceButtonClass", {}, w=150, h=20), qt_props, [])
+    assert qt_props["orientation"] == "horizontal"
+    qt_props = {}
+    _fixup_choice_button(_obj("activeChoiceButtonClass", {}, w=68, h=150), qt_props, [])
+    assert qt_props["orientation"] == "vertical"
+
+
+def test_menu_button_face_shows_current_choice():
+    node = _object_to_source(_obj("activeMenuButtonClass", {"controlPv": "X:MODE"}))
+    assert node.qt_props["labelType"] == "pvState"
+    # Without an indicatorPv the control channel doubles as the state source.
+    assert node.qt_props["readbackChannel"] == "X:MODE"
+
+    node = _object_to_source(_obj("activeMenuButtonClass", {"controlPv": "X:MODE", "indicatorPv": "X:MODE_RBV"}))
+    assert node.qt_props["readbackChannel"] == "X:MODE_RBV"
+
+
+def test_state_colors_resolve_to_hex():
+    node = _object_to_source(
+        _obj(
+            "activeButtonClass",
+            {
+                "controlPv": "X:SW",
+                "indicatorPv": "X:SW",
+                "onColor": "rgb 0 65535 0",
+                "offColor": "rgb 65535 65535 0",
+            },
+        )
+    )
+    assert node.qt_props["onColor"] == "#00ff00"
+    assert node.qt_props["offColor"] == "#ffff00"
+
+
+def test_byte_state_colors_resolve_to_hex():
+    node = _object_to_source(
+        _obj("ByteClass", {"controlPv": "X:BITS", "numBits": 4, "onColor": "rgb 0 0 65535", "offColor": "rgb 0 0 0"})
+    )
+    assert node.qt_props["onColor"] == "#0000ff"
+    assert node.qt_props["offColor"] == "#000000"

--- a/tests/edm/test_calc_rules_and_locals.py
+++ b/tests/edm/test_calc_rules_and_locals.py
@@ -1,0 +1,61 @@
+"""Iteration-3 WS2 regressions (converter side): CALC visibility PVs hoist to
+fox:// formulas (including reuse without short-form leaks), named calcs resolve
+via a sibling calc.list, LOC args survive as loc:// bindings, and EPICS calc
+function names lower to the Fox namespace."""
+
+from pathlib import Path
+
+from pydmconverter.edm.ir_adapter import edm_file_to_ir
+from pydmconverter.ir.fox import to_fox_expression
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _convert():
+    # calc.list resolution: the fixture dir holds a calc.list defining `sum`.
+    return edm_file_to_ir(FIXTURES / "calc_rules.edl")
+
+
+def test_calc_vis_pvs_hoist_to_fox_formulas():
+    screen = _convert()
+    rects = screen.root.children
+    for rect in rects[:2]:
+        rule = rect.rules[0]
+        assert rule.pvs[0].name.startswith("fox://")
+    # Identical calcs intern to ONE formula; no calc:// short forms survive.
+    assert rects[0].rules[0].pvs[0].name == rects[1].rules[0].pvs[0].name
+    assert len(screen.formulas) == 2  # MAX pair + sum
+
+
+def test_calc_function_names_lower_to_fox_namespace():
+    screen = _convert()
+    max_formula = next(f for f in screen.formulas if "max(" in f.expression)
+    assert "MAX(" not in max_formula.expression
+    assert sorted(max_formula.bindings.values()) == ["SIG:ONE.SEVR", "SIG:TWO.SEVR"]
+
+
+def test_named_calc_resolves_via_sibling_calc_list_with_loc_bindings():
+    screen = _convert()
+    sum_formula = next(f for f in screen.formulas if f.expression == "{A}+{B}" or f.expression == "A+B")
+    values = sorted(sum_formula.bindings.values())
+    assert all(value.startswith("loc://") for value in values)
+    assert any("posVis" in value for value in values)
+
+
+def test_no_raw_calc_or_short_calc_urls_survive_in_ir():
+    import json
+
+    from pydmconverter.ir.emit import to_wire_dict
+
+    wire = json.dumps(to_wire_dict(_convert()))
+    assert "CALC\\" not in wire.replace("\\\\", "\\")
+    assert "calc://" not in wire
+
+
+def test_to_fox_expression_lowering():
+    assert to_fox_expression("MAX(A,B)") == "max(A,B)"
+    assert to_fox_expression("SQR(A)+LN(B)") == "sqrt(A)+log(B)"
+    # Single-letter variables named like function initials stay untouched.
+    assert to_fox_expression("A + B") == "A + B"
+    # Idempotent on already-lowered input.
+    assert to_fox_expression("max(A,B)") == "max(A,B)"

--- a/tests/edm/test_channel_attrs_and_alarm_rules.py
+++ b/tests/edm/test_channel_attrs_and_alarm_rules.py
@@ -37,6 +37,18 @@ def test_two_channel_button_keeps_control_as_channel_and_maps_readback():
     assert warnings == []
 
 
+def test_menu_button_maps_indicator_to_readback():
+    qt_props, warnings = {}, []
+    obj = _obj(
+        "activeMenuButtonClass",
+        {"controlPv": "CAMR:X:Acquire", "indicatorPv": "CAMR:X:DetectorState_RBV"},
+    )
+    _apply_channel_attrs(obj, qt_props, warnings)
+    assert qt_props["channel"] == "CAMR:X:Acquire"
+    assert qt_props["readbackChannel"] == "CAMR:X:DetectorState_RBV"
+    assert warnings == []
+
+
 def test_choice_button_control_wins_and_indicator_drop_is_loud():
     qt_props, warnings = {}, []
     obj = _obj(

--- a/tests/edm/test_channel_attrs_and_alarm_rules.py
+++ b/tests/edm/test_channel_attrs_and_alarm_rules.py
@@ -1,0 +1,162 @@
+"""Regression tests for the iteration-3 WS1 fixes: multi-channel attr routing
+(controlPv/indicatorPv split instead of last-wins funneling), alarmPv-driven
+alarm-color rules, and closed/filled activeLineClass -> polygon."""
+
+from pydmconverter.edm.edm_qt import has_pv, resolve_qt_class
+from pydmconverter.edm.ir_adapter import (
+    _alarm_rules,
+    _apply_channel_attrs,
+    _fixup_line,
+    _fixup_state_button,
+    _object_to_source,
+    _severity_channel,
+)
+from pydmconverter.edm.parser import EDMObject
+
+
+def _obj(name, properties, w=10, h=10):
+    obj = EDMObject.__new__(EDMObject)
+    obj.name = name
+    obj.properties = properties
+    obj.x, obj.y, obj.width, obj.height = 0, 0, w, h
+    return obj
+
+
+# ── channel routing ──────────────────────────────────────────────────────────
+
+
+def test_two_channel_button_keeps_control_as_channel_and_maps_readback():
+    qt_props, warnings = {}, []
+    obj = _obj(
+        "activeButtonClass",
+        {"controlPv": "$(dev):HSTAMODESET", "indicatorPv": "$(dev):HSTAMODE"},
+    )
+    _apply_channel_attrs(obj, qt_props, warnings)
+    assert qt_props["channel"] == "${dev}:HSTAMODESET"
+    assert qt_props["readbackChannel"] == "${dev}:HSTAMODE"
+    assert warnings == []
+
+
+def test_choice_button_control_wins_and_indicator_drop_is_loud():
+    qt_props, warnings = {}, []
+    obj = _obj(
+        "activeChoiceButtonClass",
+        {"controlPv": "X:SET", "indicatorPv": "X:RBV"},
+    )
+    _apply_channel_attrs(obj, qt_props, warnings)
+    assert qt_props["channel"] == "X:SET"
+    assert "readbackChannel" not in qt_props
+    assert any("indicatorPv readback dropped" in w for w in warnings)
+
+
+def test_alarm_pv_never_becomes_the_channel():
+    qt_props, warnings = {}, []
+    obj = _obj("activeRectangleClass", {"alarmPv": "X:STAT"})
+    _apply_channel_attrs(obj, qt_props, warnings)
+    assert "channel" not in qt_props
+
+
+def test_static_label_with_alarm_pv_stays_static():
+    props = {"value": ["Fault"], "alarmPv": "X:STAT", "fgAlarm": True}
+    assert not has_pv(props)
+    assert resolve_qt_class("activextextclass", props) == "QLabel"
+
+
+# ── alarm rules ──────────────────────────────────────────────────────────────
+
+
+def test_alarm_rectangle_emits_line_and_fill_rules():
+    obj = _obj(
+        "activeRectangleClass",
+        {"alarmPv": "FBCK:FB04:LG01:A1_S", "lineAlarm": True, "fillAlarm": True, "fill": True},
+    )
+    rules = _alarm_rules(obj)
+    assert [r.target_property for r in rules] == ["lineColor", "fillColor"]
+    for rule in rules:
+        assert rule.pvs == [("FBCK:FB04:LG01:A1_S.SEVR", True)]
+        assert rule.default == "#00c000"
+        assert ("{0} == 2", "#ff0000") in rule.conditions
+
+
+def test_alarm_pv_without_flags_is_ignored_like_edm():
+    obj = _obj("activeRectangleClass", {"alarmPv": "X:STAT", "fill": True})
+    assert _alarm_rules(obj) == []
+
+
+def test_severity_channel_strips_field_refs_and_keeps_sevr():
+    assert _severity_channel("A:B") == "A:B.SEVR"
+    assert _severity_channel("A:B.SEVR") == "A:B.SEVR"
+    assert _severity_channel("EVR:FEE1:203:CTRL.PLOK") == "EVR:FEE1:203:CTRL.SEVR"
+
+
+def test_label_fg_alarm_with_alarm_pv_becomes_rule_and_drops_alarm_sensitive():
+    obj = _obj(
+        "activeXTextClass",
+        {"value": ["OK"], "alarmPv": "X:STAT", "fgAlarm": True},
+    )
+    node = _object_to_source(obj)
+    assert node.qt_class == "QLabel"
+    assert "alarmSensitiveContent" not in node.qt_props
+    assert [r.target_property for r in node.rules] == ["foregroundColor"]
+
+
+def test_visibility_rule_appends_to_alarm_rules():
+    from pydmconverter.edm.ir_adapter import edm_group_to_source_nodes
+    from pydmconverter.edm.parser import EDMGroup
+
+    obj = _obj(
+        "activeRectangleClass",
+        {"alarmPv": "X:STAT", "lineAlarm": True, "visPv": "X:VIS", "visMin": "1", "visMax": "5"},
+    )
+    group = EDMGroup.__new__(EDMGroup)
+    group.objects = [obj]
+    group.properties = {}
+    group.x = group.y = 0
+    group.width = group.height = 100
+    nodes = edm_group_to_source_nodes(group)
+    targets = [r.target_property for r in nodes[0].rules]
+    assert targets == ["lineColor", "visible"]
+
+
+# ── state buttons ────────────────────────────────────────────────────────────
+
+
+def test_state_button_with_readback_carries_live_labels_without_warning():
+    qt_props = {"readbackChannel": "X:STATE"}
+    warnings = []
+    obj = _obj("activeButtonClass", {"onLabel": "Enabled", "offLabel": "Disabled"})
+    _fixup_state_button(obj, qt_props, warnings)
+    assert qt_props["text"] == "Disabled"
+    assert qt_props["buttonType"] == "toggle"
+    assert warnings == []
+
+
+def test_state_button_without_readback_still_warns_on_differing_labels():
+    qt_props, warnings = {}, []
+    obj = _obj("activeButtonClass", {"onLabel": "Running", "offLabel": "Stopped"})
+    _fixup_state_button(obj, qt_props, warnings)
+    assert any("resting" in w for w in warnings)
+
+
+# ── closed/filled polylines ──────────────────────────────────────────────────
+
+
+def test_filled_line_resolves_to_polygon_and_keeps_fill():
+    props = {
+        "fill": True,
+        "fillColor": "index 14",
+        "xPoints": ["0", "10", "5"],
+        "yPoints": ["10", "10", "0"],
+    }
+    assert resolve_qt_class("activelineclass", props) == "PyDMDrawingIrregularPolygon"
+    qt_props, warnings = {"brushFill": True, "brushColor": "#111111"}, []
+    _fixup_line(_obj("activeLineClass", props), qt_props, warnings)
+    assert qt_props["closePolygon"] is True
+    assert qt_props["brushFill"] is True
+    assert qt_props["brushColor"] == "#111111"
+    assert not any("open polyline" in w for w in warnings)
+
+
+def test_open_line_stays_polyline():
+    props = {"xPoints": ["0", "10"], "yPoints": ["0", "10"]}
+    assert resolve_qt_class("activelineclass", props) == "PyDMDrawingPolyline"

--- a/tests/edm/test_fidelity_edm_batch.py
+++ b/tests/edm/test_fidelity_edm_batch.py
@@ -52,5 +52,8 @@ def test_xygraph_traces_become_curve_json():
     _fixup_xy_graph(obj, qt_props, warnings)
     curves = [json.loads(c) for c in qt_props["curves"]]
     assert [c["y_channel"] for c in curves] == ["SIG:ONE", "SIG:TWO"]
+    # The single xPv pairs with the first trace (waveform-vs-waveform).
+    assert curves[0]["x_channel"] == "T:BASE"
+    assert "x_channel" not in curves[1]
     assert qt_props["title"] == "Kly Fwd"
-    assert any("x-channel" in w for w in warnings)
+    assert warnings == []

--- a/tests/edm/test_fidelity_edm_batch.py
+++ b/tests/edm/test_fidelity_edm_batch.py
@@ -1,0 +1,56 @@
+"""Regression tests for the fidelity/edm-batch fixes: state-button labels,
+xyGraph -> waveform-plot curves, and screen background carry-through."""
+
+import json
+
+from pydmconverter.edm.edm_qt import EDM_TO_QT_CLASS
+from pydmconverter.edm.ir_adapter import _fixup_state_button, _fixup_xy_graph
+from pydmconverter.edm.parser import EDMObject
+
+
+def _obj(name, properties):
+    obj = EDMObject.__new__(EDMObject)
+    obj.name = name
+    obj.properties = properties
+    obj.x, obj.y, obj.width, obj.height = 0, 0, 10, 10
+    return obj
+
+
+def test_message_button_falls_back_to_off_label():
+    qt_props = {}
+    warnings = []
+    obj = _obj("activeMessageButtonClass", {"onLabel": "HV Off", "offLabel": "HV Off"})
+    _fixup_state_button(obj, qt_props, warnings)
+    assert qt_props["text"] == "HV Off"
+    assert warnings == []
+
+
+def test_state_button_notes_differing_labels_and_keeps_resting():
+    qt_props = {}
+    warnings = []
+    obj = _obj("activeButtonClass", {"onLabel": "Running", "offLabel": "Stopped"})
+    _fixup_state_button(obj, qt_props, warnings)
+    assert qt_props["text"] == "Stopped"
+    assert any("resting" in w for w in warnings)
+
+
+def test_state_button_keeps_existing_text():
+    qt_props = {"text": "Authored"}
+    obj = _obj("activeMessageButtonClass", {"offLabel": "Ignored"})
+    _fixup_state_button(obj, qt_props, [])
+    assert qt_props["text"] == "Authored"
+
+
+def test_xygraph_maps_to_waveform_plot_class():
+    assert EDM_TO_QT_CLASS["xygraphclass"] == "PyDMWaveformPlot"
+
+
+def test_xygraph_traces_become_curve_json():
+    qt_props = {}
+    warnings = []
+    obj = _obj("xyGraphClass", {"yPv": ["0 SIG:ONE", "1 SIG:TWO"], "graphTitle": "Kly Fwd", "xPv": "T:BASE"})
+    _fixup_xy_graph(obj, qt_props, warnings)
+    curves = [json.loads(c) for c in qt_props["curves"]]
+    assert [c["y_channel"] for c in curves] == ["SIG:ONE", "SIG:TWO"]
+    assert qt_props["title"] == "Kly Fwd"
+    assert any("x-channel" in w for w in warnings)

--- a/tests/edm/test_graphics_widgets.py
+++ b/tests/edm/test_graphics_widgets.py
@@ -36,11 +36,14 @@ def test_rectangle_invisible_becomes_opacity_100():
     assert rect.props["opacity"] == 100
 
 
-def test_rectangle_zero_width_promoted_and_alarm_warning():
+def test_rectangle_zero_width_promoted_and_alarm_rules():
     rect = _convert("graphics_rect.edl").root.children[2]
     assert rect.props["lineWidth"] == 1
-    assert len(rect.warnings) == 1
-    assert "lineAlarm, fillAlarm" in rect.warnings[0]
+    # alarmPv + lineAlarm/fillAlarm now become alarm-color rules, not a warning.
+    assert rect.warnings == []
+    assert [rule.target_property for rule in rect.rules] == ["lineColor", "fillColor"]
+    assert all(rule.pvs[0].name.endswith(":STAT.SEVR") for rule in rect.rules)
+    assert all(rule.default == "#00c000" for rule in rect.rules)
 
 
 # ---------------------------------------------------------------------------
@@ -83,11 +86,14 @@ def test_line_without_arrows_prop_gets_explicit_false_both_ends():
     assert "arrowEnd" in line.props
 
 
-def test_line_filled_closed_polygon_warns_and_drops_fill_props():
-    line = _convert("graphics_line.edl").root.children[2]
-    assert any("filled/closed polygon" in w for w in line.warnings)
-    assert "fill" not in line.props
-    assert "fillColor" not in line.props
+def test_line_filled_closed_polygon_becomes_polygon_widget():
+    polygon = _convert("graphics_line.edl").root.children[2]
+    assert polygon.type == "polygon"
+    assert not any("open polyline" in w for w in polygon.warnings)
+    assert polygon.props["fill"] is True
+    assert polygon.props["fillColor"]
+    assert polygon.props["closed"] is True
+    assert [(p["x"], p["y"]) for p in polygon.props["points"]] == [(0, 0), (30, 40), (60, 0)]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/edm/test_ir_adapter.py
+++ b/tests/edm/test_ir_adapter.py
@@ -31,7 +31,7 @@ def test_static_text_maps_to_text_label():
     """
     label = _convert().root.children[0]
     assert label.type == "text-label"
-    assert label.props == {"text": "Label ${PREFIX}", "foregroundColor": "#000000"}
+    assert label.props == {"text": "Label ${PREFIX}", "foregroundColor": "#000000", "fontSize": 12}
     assert label.geometry.model_dump() == {"x": 10, "y": 20, "width": 120, "height": 18}
 
 

--- a/tests/edm/test_pip_and_macro_declarations.py
+++ b/tests/edm/test_pip_and_macro_declarations.py
@@ -1,0 +1,47 @@
+"""Iteration-3 WS4 regressions: activePipClass file handling per displaySource
+(menu pips gain a filePv-keyed `file` rule) and macro declarations discovered
+inside structured props (action commands, rule PVs)."""
+
+from pathlib import Path
+
+from pydmconverter.edm.ir_adapter import edm_file_to_ir
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _convert(name):
+    return edm_file_to_ir(FIXTURES / name)
+
+
+def test_menu_pip_gets_static_file_and_switching_rule():
+    screen = _convert("pip_menu.edl")
+    pip = screen.root.children[0]
+    assert pip.type == "embedded-display"
+    assert pip.props["file"] == "TEMnocentroid.screen.json"
+    rules = [r for r in pip.rules if r.target_property == "file"]
+    assert len(rules) == 1
+    rule = rules[0]
+    assert rule.pvs[0].name == "${TEMLOCATION}:INAPOSITION"
+    assert [(c.expression, c.value) for c in rule.conditions] == [
+        ("{0} == 0", "TEMnocentroid.screen.json"),
+        ("{0} == 1", "TEMcentroid.screen.json"),
+    ]
+    assert rule.default == "TEMnocentroid.screen.json"
+
+
+def test_file_pip_keeps_macro_template():
+    screen = _convert("pip_menu.edl")
+    pip = screen.root.children[1]
+    assert pip.type == "embedded-display"
+    # ${VAR} form preserved for view-time resolution; extension appended is
+    # deferred (macro refs cannot be rewritten by screenRef).
+    assert pip.props["file"] == "mgnt_unit_${DISP}"
+    assert not [r for r in pip.rules if r.target_property == "file"]
+
+
+def test_macros_declared_from_rule_pvs_and_action_commands():
+    screen = _convert("pip_menu.edl")
+    declared = {m.name for m in screen.macros}
+    # TEMLOCATION rides the menu pip's file rule; DISP the file template;
+    # STRIPCONFIG hides inside the shell-command actions list.
+    assert {"TEMLOCATION", "DISP", "STRIPCONFIG"} <= declared

--- a/tests/edm/test_symbol_states.py
+++ b/tests/edm/test_symbol_states.py
@@ -1,0 +1,41 @@
+"""Iteration-3 WS3 regressions: activeSymbolClass state groups become
+complementary visibility rules over the symbol channel (instead of every
+state rendering stacked), and the symbol file resolves beside the display."""
+
+from pathlib import Path
+
+from pydmconverter.edm.ir_adapter import edm_file_to_ir
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _symbol_groups():
+    screen = edm_file_to_ir(FIXTURES / "symbol_two_state.edl")
+    container = screen.root.children[0]
+    assert container.type == "group"
+    states = [child for child in container.children if child.type == "group"]
+    return states
+
+
+def test_two_state_symbol_emits_complementary_visibility_rules():
+    states = _symbol_groups()
+    assert len(states) == 2
+
+    seen = []
+    for state in states:
+        vis_rules = [r for r in state.rules if r.target_property == "visible"]
+        assert len(vis_rules) == 1
+        rule = vis_rules[0]
+        assert rule.pvs[0].name == "${dev}:MOTOR_STATE"
+        assert rule.default is False
+        seen.append(rule.conditions[0].expression)
+
+    # State 0 visible in [0, 1), state 1 in [1, 2) — complementary ranges.
+    assert "({0} >= 0.0) and ({0} < 1.0)" in seen[0]
+    assert "({0} >= 1.0) and ({0} < 2.0)" in seen[1]
+
+
+def test_symbol_state_children_render_real_widgets():
+    states = _symbol_groups()
+    child_types = [child.type for state in states for child in state.children]
+    assert child_types == ["rectangle", "ellipse"]


### PR DESCRIPTION
Conversion-fidelity work from the edm-batch loop: five complicated production EDM screens (klys/RF_station, fbck/FB04_LG01_details_1_1_1, bpms/new_bpm/bpm_cavity_diagnostics_atca, mgnt/mgnt_unit2, xray/TEMembedMaster) converted and compared against real EDM (dockerized SLAC EDM), both sides fed by one generated soft IOC.

## Changes

- EDM channel attrs no longer funnel to a single `channel` prop. controlPv wins as the primary channel, indicatorPv/readPv map to `readbackChannel` on button classes (pv-button gains readbackPV, onLabel, offLabel, buttonType), leftovers drop loudly. Fixes buttons writing to their readback PV and choice buttons losing their control PV.
- `alarmPv` is no longer a data channel. With lineAlarm/fillAlarm/fgAlarm/bgAlarm it emits alarm-color rules bound to `<pv>.SEVR` (EDM palette). Static labels with only an alarmPv stay static labels.
- activeSymbolClass state groups get complementary visibility rules over the symbol channel; symbol files resolve beside the display, with a Windows-safe EDMDATAFILES split.
- activePipClass displaySource=menu emits the first displayFileName plus a `file` rule keyed on the filePv; macros hiding in structured props (actions, rule PVs) are declared.
- CALC plumbing for the react target: `--calc-list`/`--site` reach the parser (discovery: beside the file, then $EDMFILES, then beside $EDMCOLORFILE); calc:// rule PVs hoist to fox:// formulas; short-form calc reuse disabled for react; EPICS function names lower to the Fox namespace (MAX -> max etc.); per-trace xPv becomes x_channel on waveform curves.
- Closed or filled activeLineClass resolves to the polygon widget (fill survives).
- Earlier batch commits included: EDM on/offLabel button captions, xyGraphClass -> waveform-plot with curves, screen bgColor carry-through.
- Vendored widget-registry snapshot updated in lock-step with Canopy widget-registry-data (see the companion Canopy PR).

## Verification

- 391 pytest passing (13 new WS1 tests, plus symbol, pip/macro, and calc fixtures).
- Census sourceOnly across all five screens dropped from 29 PVs to zero, with two explained residuals (a choice-button readback dropped with a warning, one flag-less alarmPv that EDM also ignores).
- Live state-pair evidence (same soft IOC, same macros, candidate vs real EDM) in the local fidelity report (test_output/fidelity/report.md on the loop machine).

## Notes

- After merge, cutting a PyDMConverter release lets the Canopy backend reach engine parity for the converter API byte-diff e2e (currently version-skewed by design).


## Batch-2 additions (87d2e3a)

A second fidelity batch (six screens from vac/mps/llrf/prof/misc subsystems, report-batch2.md) added:

- EDM `font` strings map to `fontSize` pixels on every class. Unmapped fonts previously left labels at theme size, truncating values in EDM-sized boxes (a camera FPS of "16" drew as "1").
- activeChoiceButtonClass converts to the radio-set widget (pv-radio-group) with rect-aspect orientation; EDM choice buttons show every state, and the dropdown mapping displayed only the ordinal.
- activeMenuButtonClass emits `labelType=pvState` with the control channel doubling as readback when no indicatorPv, so the face shows the current choice; menu buttons also joined the readback-mapping classes.
- `onColor`/`offColor` resolve to hex for buttons and byte indicators (registry props in lock-step with the Canopy PR).
- 8 new pytest cases; integration snapshot regenerated (2 fontSize insertions).
